### PR TITLE
Reuse task registration

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -7,61 +7,35 @@ export function startWorker(server: PluginsServer): void {
     const worker = celery.createWorker(server.REDIS_URL, server.REDIS_URL, server.PLUGINS_CELERY_QUEUE)
     const client = celery.createClient(server.REDIS_URL, server.REDIS_URL, server.CELERY_DEFAULT_QUEUE)
 
-    worker.register(
-        'posthog.tasks.process_event.process_event_with_plugins',
-        async (
-            distinct_id: string,
-            ip: string,
-            site_url: string,
-            data: Record<string, unknown>,
-            team_id: number,
-            now: string,
-            sent_at?: string
-        ) => {
-            const event = { distinct_id, ip, site_url, team_id, now, sent_at, ...data } as PluginEvent
-            const processedEvent = await runPlugins(server, event)
-            if (processedEvent) {
-                const { distinct_id, ip, site_url, team_id, now, sent_at, ...data } = processedEvent
-                client.sendTask('posthog.tasks.process_event.process_event', [], {
-                    distinct_id,
-                    ip,
-                    site_url,
-                    data,
-                    team_id,
-                    now,
-                    sent_at,
-                })
+    for (const task of ['posthog.tasks.process_event.process_event', 'ee.clickhouse.process_event.process_event_ee']) {
+        worker.register(
+            `${task}_with_plugins`,
+            async (
+                distinct_id: string,
+                ip: string,
+                site_url: string,
+                data: Record<string, unknown>,
+                team_id: number,
+                now: string,
+                sent_at?: string
+            ) => {
+                const event = { distinct_id, ip, site_url, team_id, now, sent_at, ...data } as PluginEvent
+                const processedEvent = await runPlugins(server, event)
+                if (processedEvent) {
+                    const { distinct_id, ip, site_url, team_id, now, sent_at, ...data } = processedEvent
+                    client.sendTask(task, [], {
+                        distinct_id,
+                        ip,
+                        site_url,
+                        data,
+                        team_id,
+                        now,
+                        sent_at,
+                    })
+                }
             }
-        }
-    )
-
-    worker.register(
-        'ee.clickhouse.process_event.process_event_ee_with_plugins',
-        async (
-            distinct_id: string,
-            ip: string,
-            site_url: string,
-            data: Record<string, unknown>,
-            team_id: number,
-            now: string,
-            sent_at?: string
-        ) => {
-            const event = { distinct_id, ip, site_url, team_id, now, sent_at, ...data } as PluginEvent
-            const processedEvent = await runPlugins(server, event)
-            if (processedEvent) {
-                const { distinct_id, ip, site_url, team_id, now, sent_at, ...data } = processedEvent
-                client.sendTask('ee.clickhouse.process_event.process_event_ee', [], {
-                    distinct_id,
-                    ip,
-                    site_url,
-                    data,
-                    team_id,
-                    now,
-                    sent_at,
-                })
-            }
-        }
-    )
+        )
+    }
 
     worker.start()
 }


### PR DESCRIPTION
Since apparently both base and EE task handling is the same, this ensures consistency and removes code redundancy by using the calling `worker.register` in a loop based on the only difference: task names.