### PR TITLE
Allow for optimized passing on unchanged event

### DIFF
--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -179,7 +179,7 @@ async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Pr
 export async function runPlugins(server: PluginsServer, event: PluginEvent): Promise<PluginEvent | null> {
     const pluginsToRun = pluginConfigsPerTeam.get(event.team_id) || defaultConfigs
 
-    let returnedEvent: PluginEvent | null = event
+    let returnedEvent: PluginEvent | null | undefined = event
 
     for (const pluginConfig of pluginsToRun.reverse()) {
         if (pluginConfig.vm) {
@@ -197,10 +197,10 @@ export async function runPlugins(server: PluginsServer, event: PluginEvent): Pro
                     logTime(pluginConfig.plugin.name, ms, true)
                 }
             }
-
-            if (!returnedEvent) {
-                return null
-            }
+            // if processEvent didn't return or explicitly returned undefined, pass on original event
+            if (returnedEvent === undefined) return event
+            // if processEvent returned a non-undefined falsy value, discard the event altogether
+            if (!returnedEvent) return null
         }
     }
 


### PR DESCRIPTION
This allows plugins to not have to pass on the entire event object if they want to leave it unchanged – they can just return undefined (or in other words not return anything), avoiding all the extra assignment/memory work, possibly slightly improving performance.

Would be nice to do: some benchmarking.