### PR TITLE
Remove EE task registration

### DIFF
--- a/src/worker.ts
+++ b/src/worker.ts
@@ -35,33 +35,5 @@ export function startWorker(server: PluginsServer): void {
         }
     )
 
-    worker.register(
-        'ee.clickhouse.process_event.process_event_ee_with_plugins',
-        async (
-            distinct_id: string,
-            ip: string,
-            site_url: string,
-            data: Record<string, unknown>,
-            team_id: number,
-            now: string,
-            sent_at?: string
-        ) => {
-            const event = { distinct_id, ip, site_url, team_id, now, sent_at, ...data } as PluginEvent
-            const processedEvent = await runPlugins(server, event)
-            if (processedEvent) {
-                const { distinct_id, ip, site_url, team_id, now, sent_at, ...data } = processedEvent
-                client.sendTask('ee.clickhouse.process_event.process_event_ee', [], {
-                    distinct_id,
-                    ip,
-                    site_url,
-                    data,
-                    team_id,
-                    now,
-                    sent_at,
-                })
-            }
-        }
-    )
-
     worker.start()
 }


### PR DESCRIPTION
Since EE works differently after recent changes anyway, this just removes EE-related code.