### PR TITLE
Remove start from CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "scripts": {
         "test": "yarn lint",
         "start": "yarn start:dev",
-        "start:dist": "node dist/index.js start --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
-        "start:dev": "ts-node src/index.ts start --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
+        "start:dist": "node dist/index.js --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
+        "start:dev": "ts-node src/index.ts --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
         "build": "yarn clean && yarn compile",
         "clean": "rimraf dist/*",
         "compile": "rollup -c",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,7 @@ import yargs from 'yargs'
 yargs
     .scriptName('posthog-plugins')
     .option('config', { alias: 'c', describe: 'json string of config options', type: 'string' })
-    .command('start', 'start the server', ({ argv }) => {
+    .command(['start', '$0'], 'start the server', ({ argv }) => {
         startPluginsServer(argv.config ? JSON.parse(argv.config) : {})
     })
-    .demandCommand()
     .help().argv

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,8 +29,6 @@ export interface Plugin {
     config_schema: Record<string, PluginConfigSchema> | PluginConfigSchema[]
     tag: string
     archive: Buffer | null
-    from_json: boolean
-    from_web: boolean
     error?: PluginError
 }
 

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -66,7 +66,7 @@ export function prepareForRun(
     if (!pluginConfig.vm?.methods[method]) {
         return null
     }
-    
+
     const { vm } = pluginConfig.vm
 
     if (event?.properties?.token) {


### PR DESCRIPTION
Makes it possible to just link to the `index.js` (e.g. from pm2) and have the server start without redundant CLI arguments.

Calling it with `start` will still work, so this change is backwards compatible.