### PR TITLE
Inline node celery, clean up on signals

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "types": "dist/index.d.ts",
     "main": "dist/index.js",
     "scripts": {
-        "test": "jest",
+        "test": "jest --passWithNoTests",
         "start": "yarn start:dev",
         "start:dist": "node dist/index.js --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
         "start:dev": "ts-node-dev --exit-child src/index.ts --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "types": "dist/index.d.ts",
     "main": "dist/index.js",
     "scripts": {
-        "test": "jest --passWithNoTests",
+        "test": "jest",
         "start": "yarn start:dev",
         "start:dist": "node dist/index.js --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
         "start:dev": "ts-node-dev --exit-child src/index.ts --config \"{\\\"BASE_DIR\\\": \\\"../posthog\\\"}\"",
@@ -26,7 +26,6 @@
     "license": "MIT",
     "dependencies": {
         "adm-zip": "^0.4.16",
-        "celery-node": "^0.5.0",
         "fastify": "^3.8.0",
         "gunzip-maybe": "^1.4.2",
         "ioredis": "^4.19.2",
@@ -36,6 +35,7 @@
         "posthog-js-lite": "^0.0.5",
         "posthog-plugins": "^0.1.3",
         "tar-stream": "^2.1.4",
+        "uuid": "^8.3.1",
         "vm2": "^3.9.2",
         "yargs": "^16.1.0"
     },
@@ -44,6 +44,7 @@
         "@babel/core": "^7.0.0",
         "@babel/preset-env": "^7.0.0",
         "@babel/preset-typescript": "^7.8.3",
+        "@types/uuid": "^8.3.0",
         "@rollup/plugin-json": "^4.1.0",
         "@types/adm-zip": "^0.4.33",
         "@types/gunzip-maybe": "^1.4.0",

--- a/src/celery/base.ts
+++ b/src/celery/base.ts
@@ -1,0 +1,36 @@
+/**
+ * writes here Base Parent class of Celery client and worker
+ * @author SunMyeong Lee <actumn814@gmail.com>
+ */
+import { CeleryConf, defaultConf } from './conf'
+import RedisBroker from './broker'
+import * as Redis from 'ioredis'
+
+export default class Base {
+    broker: RedisBroker
+    conf: CeleryConf
+    redis: Redis.Redis
+
+    /**
+     * Parent Class of Client and Worker
+     * for creates an instance of celery broker and celery backend
+     *
+     * @constructor Base
+     */
+    constructor(redis: Redis.Redis, queue = 'celery') {
+        this.redis = redis
+        this.conf = defaultConf()
+        this.conf.CELERY_QUEUE = queue
+        this.broker = new RedisBroker(this.redis)
+    }
+
+    /**
+     * returns promise for working some job after backend and broker ready.
+     * @method Base#disconnect
+     *
+     * @returns {Promise} promises that continues if backend and broker disconnected.
+     */
+    public disconnect(): Promise<any> {
+        return this.broker.disconnect()
+    }
+}

--- a/src/celery/broker.ts
+++ b/src/celery/broker.ts
@@ -1,0 +1,167 @@
+import * as Redis from 'ioredis'
+import { v4 } from 'uuid'
+import { Message } from './message'
+
+class RedisMessage extends Message {
+    private raw: Record<string, any>
+
+    constructor(payload: Record<string, any>) {
+        super(
+            Buffer.from(payload['body'], 'base64'),
+            payload['content-type'],
+            payload['content-encoding'],
+            payload['properties'],
+            payload['headers']
+        )
+
+        this.raw = payload
+    }
+}
+
+export default class RedisBroker {
+    redis: Redis.Redis
+    channels: Promise<void>[] = []
+    closing = false
+
+    /**
+     * Redis broker class
+     * @constructor RedisBroker
+     * @param {string} url the connection string of redis
+     * @param {object} opts the options object for redis connect of ioredis
+     */
+    constructor(redis: Redis.Redis) {
+        this.redis = redis
+    }
+
+    /**
+     * @method RedisBroker#disconnect
+     * @returns {Promise} promises that continues if redis disconnected.
+     */
+    public disconnect(): Promise<any> {
+        this.closing = true
+        return Promise.all(this.channels)
+    }
+
+    /**
+     * @method RedisBroker#publish
+     *
+     * @returns {Promise}
+     */
+    public publish(
+        body: Record<string, any> | [Array<any>, Record<string, any>, Record<string, any>],
+        exchange: string,
+        routingKey: string,
+        headers: Record<string, any>,
+        properties: Record<string, any>
+    ): Promise<number> {
+        const messageBody = JSON.stringify(body)
+        const contentType = 'application/json'
+        const contentEncoding = 'utf-8'
+        const message = {
+            body: Buffer.from(messageBody).toString('base64'),
+            'content-type': contentType,
+            'content-encoding': contentEncoding,
+            headers,
+            properties: {
+                body_encoding: 'base64',
+                delivery_info: {
+                    exchange: exchange,
+                    routing_key: routingKey,
+                },
+                delivery_mode: 2,
+                delivery_tag: v4(),
+                ...properties,
+            },
+        }
+
+        return this.redis.lpush(routingKey, JSON.stringify(message))
+    }
+
+    /**
+     * @method RedisBroker#subscribe
+     * @param {string} queue
+     * @param {Function} callback
+     * @returns {Promise}
+     */
+    public subscribe(queue: string, callback: (message: Message) => any): Promise<any[]> {
+        const promiseCount = 1
+
+        for (let index = 0; index < promiseCount; index += 1) {
+            this.channels.push(new Promise((resolve) => this.receive(index, resolve, queue, callback)))
+        }
+
+        return Promise.all(this.channels)
+    }
+
+    /**
+     * @private
+     * @param {number} index
+     * @param {Fucntion} resolve
+     * @param {string} queue
+     * @param {Function} callback
+     */
+    private receive(index: number, resolve: () => void, queue: string, callback: (message: Message) => any): void {
+        process.nextTick(() => this.recieveOneOnNextTick(index, resolve, queue, callback))
+    }
+
+    /**
+     * @private
+     * @param {number} index
+     * @param {Function} resolve
+     * @param {String} queue
+     * @param {Function} callback
+     * @returns {Promise}
+     */
+    private async recieveOneOnNextTick(
+        index: number,
+        resolve: () => void,
+        queue: string,
+        callback: (message: Message) => any
+    ): Promise<void> {
+        if (this.closing) {
+            resolve()
+            return
+        }
+
+        return this.receiveOne(queue)
+            .then((body) => {
+                if (body) {
+                    callback(body)
+                }
+                Promise.resolve()
+            })
+            .then(() => this.receive(index, resolve, queue, callback))
+            .catch((err) => console.log(err))
+    }
+
+    /**
+     * @private
+     * @param {string} queue
+     * @return {Promise}
+     */
+    private async receiveOne(queue: string): Promise<Message | null> {
+        return this.redis.brpop(queue, '5').then((result) => {
+            if (!result) {
+                return null
+            }
+
+            const [queue, item] = result
+            const rawMsg = JSON.parse(item)
+
+            // now supports only application/json of content-type
+            if (rawMsg['content-type'] !== 'application/json') {
+                throw new Error(`queue ${queue} item: unsupported content type ${rawMsg['content-type']}`)
+            }
+            // now supports only base64 of body_encoding
+            if (rawMsg.properties.body_encoding !== 'base64') {
+                throw new Error(`queue ${queue} item: unsupported body encoding ${rawMsg.properties.body_encoding}`)
+            }
+            // now supports only utf-8 of content-encoding
+            if (rawMsg['content-encoding'] !== 'utf-8') {
+                throw new Error(`queue ${queue} item: unsupported content encoding ${rawMsg['content-encoding']}`)
+            }
+
+            return new RedisMessage(rawMsg)
+        })
+    }
+}

--- a/src/celery/client.ts
+++ b/src/celery/client.ts
@@ -1,0 +1,112 @@
+import { v4 } from 'uuid'
+import Base from './base'
+import Task from './task'
+
+class TaskMessage {
+    constructor(
+        readonly headers: Record<string, any>,
+        readonly properties: Record<string, any>,
+        readonly body: [Array<any>, Record<string, any>, Record<string, any>] | Record<string, any>,
+        readonly sentEvent: Record<string, any> | null
+    ) {}
+}
+
+export default class Client extends Base {
+    private taskProtocols = {
+        1: this.asTaskV1,
+        2: this.asTaskV2,
+    }
+
+    get createTaskMessage(): (...args: any[]) => TaskMessage {
+        return this.taskProtocols[this.conf.TASK_PROTOCOL]
+    }
+
+    public sendTaskMessage(taskName: string, message: TaskMessage): void {
+        const { headers, properties, body /*, sentEvent */ } = message
+
+        const exchange = ''
+        // exchangeType = 'direct';
+        // const serializer = 'json';
+
+        this.broker.publish(body, exchange, this.conf.CELERY_QUEUE, headers, properties)
+    }
+
+    public asTaskV2(taskId: string, taskName: string, args?: Array<any>, kwargs?: Record<string, any>): TaskMessage {
+        const message: TaskMessage = {
+            headers: {
+                lang: 'js',
+                task: taskName,
+                id: taskId,
+                /*
+        'shadow': shadow,
+        'eta': eta,
+        'expires': expires,
+        'group': group_id,
+        'retries': retries,
+        'timelimit': [time_limit, soft_time_limit],
+        'root_id': root_id,
+        'parent_id': parent_id,
+        'argsrepr': argsrepr,
+        'kwargsrepr': kwargsrepr,
+        'origin': origin or anon_nodename()
+        */
+            },
+            properties: {
+                correlationId: taskId,
+                replyTo: '',
+            },
+            body: [args, kwargs, {}],
+            sentEvent: null,
+        }
+
+        return message
+    }
+
+    /**
+     * create json string representing celery task message. used by Client.publish
+     *
+     * celery protocol reference: https://docs.celeryproject.org/en/latest/internals/protocol.html
+     * celery code: https://github.com/celery/celery/blob/4aefccf8a89bffe9dac9a72f2601db1fa8474f5d/celery/app/amqp.py#L307-L464
+     *
+     * @function createTaskMessage
+     *
+     * @returns {String} JSON serialized string of celery task message
+     */
+    public asTaskV1(taskId: string, taskName: string, args?: Array<any>, kwargs?: Record<string, any>): TaskMessage {
+        const message: TaskMessage = {
+            headers: {},
+            properties: {
+                correlationId: taskId,
+                replyTo: '',
+            },
+            body: {
+                task: taskName,
+                id: taskId,
+                args: args,
+                kwargs: kwargs,
+            },
+            sentEvent: null,
+        }
+
+        return message
+    }
+
+    /**
+     * createTask
+     * @method Client#createTask
+     * @param {string} name for task name
+     * @returns {Task} task object
+     *
+     * @example
+     * client.createTask('task.add').delay([1, 2])
+     */
+    public createTask(name: string): Task {
+        return new Task(this, name)
+    }
+
+    public sendTask(taskName: string, args?: Array<any>, kwargs?: Record<string, any>, taskId?: string): void {
+        taskId = taskId || v4()
+        const message = this.createTaskMessage(taskId, taskName, args, kwargs)
+        this.sendTaskMessage(taskName, message)
+    }
+}

--- a/src/celery/conf.ts
+++ b/src/celery/conf.ts
@@ -1,0 +1,11 @@
+export interface CeleryConf {
+    CELERY_QUEUE: string
+    TASK_PROTOCOL: 1 | 2
+}
+
+export function defaultConf(): CeleryConf {
+    return {
+        CELERY_QUEUE: 'celery',
+        TASK_PROTOCOL: 2,
+    }
+}

--- a/src/celery/message.ts
+++ b/src/celery/message.ts
@@ -1,0 +1,21 @@
+export class Message {
+    private _decode: Record<string, any> | null = null
+
+    // public deliveryInfo: object;
+    // public deliveryTag: string;
+    constructor(
+        readonly body: Buffer,
+        readonly contentType: string,
+        readonly contentEncoding: string,
+        readonly properties: Record<string, any>,
+        readonly headers: Record<string, any>
+    ) {}
+
+    public decode(): Record<string, any> {
+        if (!this._decode) {
+            // now only support application/json, utf-8
+            this._decode = JSON.parse(this.body.toString('utf-8'))
+        }
+        return this._decode as Record<string, any>
+    }
+}

--- a/src/celery/task.ts
+++ b/src/celery/task.ts
@@ -1,0 +1,39 @@
+import Client from './client'
+
+export default class Task {
+    client: Client
+    name: string
+
+    /**
+     * Asynchronous Task
+     * @constructor Task
+     * @param {Client} clinet celery client instance
+     * @param {string} name celery task name
+     */
+    constructor(client: Client, name: string) {
+        this.client = client
+        this.name = name
+    }
+
+    /**
+     * @method Task#delay
+     *
+     * @example
+     * client.createTask('task.add').delay(1, 2)
+     */
+    public delay(...args: any[]): void {
+        return this.applyAsync([...args])
+    }
+
+    public applyAsync(args: Array<any>, kwargs?: Record<string, any>): void {
+        if (args && !Array.isArray(args)) {
+            throw new Error('args is not array')
+        }
+
+        if (kwargs && typeof kwargs !== 'object') {
+            throw new Error('kwargs is not object')
+        }
+
+        return this.client.sendTask(this.name, args || [], kwargs || {})
+    }
+}

--- a/src/celery/worker.ts
+++ b/src/celery/worker.ts
@@ -1,0 +1,190 @@
+import Base from './base'
+import { Message } from './message'
+
+type Handler = (...args: any[]) => Promise<void>
+
+export default class Worker extends Base {
+    handlers: Record<string, Handler> = {}
+    activeTasks: Set<Promise<any>> = new Set()
+
+    /**
+     * register task handler on worker handlers
+     * @method Worker#register
+     * @param {String} name the name of task for dispatching.
+     * @param {Function} handler the function for task handling
+     *
+     * @example
+     * worker.register('tasks.add', (a, b) => a + b);
+     * worker.start();
+     */
+    public register(name: string, handler: Handler): void {
+        if (!handler) {
+            throw new Error('Undefined handler')
+        }
+        if (this.handlers[name]) {
+            throw new Error('Already handler setted')
+        }
+
+        this.handlers[name] = function registHandler(...args: any[]): Promise<any> {
+            try {
+                return Promise.resolve(handler(...args))
+            } catch (err) {
+                return Promise.reject(err)
+            }
+        }
+    }
+
+    /**
+     * start celery worker to run
+     * @method Worker#start
+     * @example
+     * worker.register('tasks.add', (a, b) => a + b);
+     * worker.start();
+     */
+    public start(): Promise<any> {
+        console.info('celery.node worker start...')
+        console.info(`registed task: ${Object.keys(this.handlers)}`)
+        return this.run().catch((err) => console.error(err))
+    }
+
+    /**
+     * @method Worker#run
+     * @private
+     *
+     * @returns {Promise}
+     */
+    private run(): Promise<any> {
+        return this.processTasks()
+    }
+
+    /**
+     * @method Worker#processTasks
+     * @private
+     *
+     * @returns function results
+     */
+    private processTasks(): Promise<any> {
+        const consumer = this.getConsumer(this.conf.CELERY_QUEUE)
+        return consumer()
+    }
+
+    /**
+     * @method Worker#getConsumer
+     * @private
+     *
+     * @param {String} queue queue name for task route
+     */
+    private getConsumer(queue: string): () => any {
+        const onMessage = this.createTaskHandler()
+
+        return () => this.broker.subscribe(queue, onMessage)
+    }
+
+    public createTaskHandler(): (message: Message) => any {
+        const onTaskReceived = (message: Message): any => {
+            if (!message) {
+                return Promise.resolve()
+            }
+
+            let payload: Record<string, any> | null = null
+            let taskName = message.headers['task']
+            if (!taskName) {
+                // protocol v1
+                payload = message.decode()
+                taskName = payload['task']
+            }
+
+            // strategy
+            let body
+            let headers
+            if (payload == null && !('args' in message.decode())) {
+                body = message.decode() // message.body;
+                headers = message.headers
+            } else if (payload) {
+                const args = payload['args'] || []
+                const kwargs = payload['kwargs'] || {}
+                const embed = {
+                    callbacks: payload['callbacks'],
+                    errbacks: payload['errbacks'],
+                    chord: payload['chord'],
+                    chain: null,
+                }
+
+                body = [args, kwargs, embed]
+                headers = {
+                    lang: payload['lang'],
+                    task: payload['task'],
+                    id: payload['id'],
+                    rootId: payload['root_id'],
+                    parantId: payload['parentId'],
+                    group: payload['group'],
+                    meth: payload['meth'],
+                    shadow: payload['shadow'],
+                    eta: payload['eta'],
+                    expires: payload['expires'],
+                    retries: payload['retries'] || 0,
+                    timelimit: payload['timelimit'] || [null, null],
+                    kwargsrepr: payload['kwargsrepr'],
+                    origin: payload['origin'],
+                }
+            }
+
+            // request
+            const [args, kwargs /*, embed */] = body as [Array<any>, Record<string, any>, Record<string, any>]
+            const taskId = headers ? headers['id'] : null
+
+            const handler = this.handlers[taskName]
+            if (!handler) {
+                throw new Error(`Missing process handler for task ${taskName}`)
+            }
+
+            console.info(
+                `celery.node Received task: ${taskName}[${taskId}], args: ${args}, kwargs: ${JSON.stringify(kwargs)}`
+            )
+
+            const timeStart = process.hrtime()
+            const taskPromise = handler(...args, kwargs).then((result) => {
+                const diff = process.hrtime(timeStart)
+                console.info(
+                    `celery.node Task ${taskName}[${taskId}] succeeded in ${diff[0] + diff[1] / 1e9}s: ${result}`
+                )
+                this.activeTasks.delete(taskPromise)
+            })
+
+            // record the executing task
+            this.activeTasks.add(taskPromise)
+
+            return taskPromise
+        }
+
+        return onTaskReceived
+    }
+
+    /**
+     * @method Worker#whenCurrentJobsFinished
+     *
+     * @returns Promise that resolves when all jobs are finished
+     */
+    public async whenCurrentJobsFinished(): Promise<any[]> {
+        return Promise.all(Array.from(this.activeTasks))
+    }
+
+    /**
+     * @method Worker#stop
+     *
+     * @todo implement here
+     */
+    // eslint-disable-next-line class-methods-use-this
+    public async stop(): Promise<void> {
+        const taskCount = this.activeTasks.size
+        if (taskCount > 0) {
+            console.log(`In progress: ${taskCount} tasks. Waiting for them to finish.`)
+            await this.whenCurrentJobsFinished()
+            console.log(`Finished. Shutting down celery worker.`)
+        } else {
+            console.log(`No tasks in progress, shutting down celery worker`)
+        }
+
+        this.disconnect()
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import yargs from 'yargs'
 import { PluginsServerConfig } from './types'
 import { startPluginsServer } from './server'
-import { startWebServer } from './web/server'
 
 type Argv = {
     config: string
@@ -21,10 +20,12 @@ yargs
         command: ['start', '$0'],
         describe: 'start the server',
         handler: ({ config, disableWeb, webPort, webHostname }: Argv) => {
-            const parsedConfig: PluginsServerConfig = config ? JSON.parse(config) : {}
-            startPluginsServer(parsedConfig)
-            if (!disableWeb) {
-                startWebServer(webPort, webHostname)
+            const parsedConfig: PluginsServerConfig = {
+                ...(config ? JSON.parse(config) : {}),
+                WEB_HOSTNAME: webHostname,
+                WEB_PORT: webPort,
+                DISABLE_WEB: disableWeb,
             }
+            startPluginsServer(parsedConfig)
         },
     }).argv

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { setupPlugins } from './plugins'
 import { startWorker } from './worker'
 import schedule from 'node-schedule'
 import Redis from 'ioredis'
+import { startWebServer, stopWebServer } from './web/server'
 
 const defaultConfig: PluginsServerConfig = {
     CELERY_DEFAULT_QUEUE: 'celery',
@@ -13,6 +14,9 @@ const defaultConfig: PluginsServerConfig = {
     REDIS_URL: 'redis://localhost/',
     BASE_DIR: '.',
     PLUGINS_RELOAD_PUBSUB_CHANNEL: 'reload-plugins',
+    DISABLE_WEB: false,
+    WEB_PORT: 3008,
+    WEB_HOSTNAME: '0.0.0.0',
 }
 
 export async function startPluginsServer(config: PluginsServerConfig): Promise<void> {
@@ -26,6 +30,7 @@ export async function startPluginsServer(config: PluginsServerConfig): Promise<v
     const db = new Pool({
         connectionString: serverConfig.DATABASE_URL,
     })
+
     const redis = new Redis(serverConfig.REDIS_URL)
 
     const server: PluginsServer = {
@@ -35,7 +40,12 @@ export async function startPluginsServer(config: PluginsServerConfig): Promise<v
     }
 
     await setupPlugins(server)
-    startWorker(server)
+
+    if (!serverConfig.DISABLE_WEB) {
+        await startWebServer(serverConfig.WEB_PORT, serverConfig.WEB_HOSTNAME)
+    }
+
+    const stopWorker = startWorker(server)
 
     const pubSub = new Redis(serverConfig.REDIS_URL)
     pubSub.subscribe(serverConfig.PLUGINS_RELOAD_PUBSUB_CHANNEL)
@@ -47,10 +57,22 @@ export async function startPluginsServer(config: PluginsServerConfig): Promise<v
     })
 
     // every 5 sec set a @posthog-plugin-server/ping redis key
-    schedule.scheduleJob('*/5 * * * * *', function () {
+    const job = schedule.scheduleJob('*/5 * * * * *', function () {
         redis.set('@posthog-plugin-server/ping', new Date().toISOString())
         redis.expire('@posthog-plugin-server/ping', 60)
     })
-
     console.info(`✅ Started posthog-plugin-server v${version}!`)
+
+    for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
+        process.on(signal, async () => {
+            if (!serverConfig.DISABLE_WEB) {
+                await stopWebServer()
+            }
+            stopWorker()
+            pubSub.disconnect()
+            schedule.cancelJob(job)
+            await redis.quit()
+            await db.end()
+        })
+    }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,9 @@ export interface PluginsServerConfig {
     REDIS_URL: string
     BASE_DIR: string
     PLUGINS_RELOAD_PUBSUB_CHANNEL: string
+    DISABLE_WEB: boolean
+    WEB_PORT: number
+    WEB_HOSTNAME: string
 }
 
 export interface PluginsServer extends PluginsServerConfig {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -9,23 +9,13 @@ async function getEvent(request: FastifyRequest, reply: FastifyReply): Promise<R
 webServer.get('*', getEvent)
 webServer.post('*', getEvent)
 
-export async function startWebServer(
-    port: string | number = 3008,
-    hostname?: string,
-    withSignalHandling = true
-): Promise<void> {
+export async function startWebServer(port: string | number, hostname?: string): Promise<void> {
     console.info(`👾 Starting web server…`)
     try {
         const address = await webServer.listen(port, hostname)
         console.info(`✅ Web server listening on ${address}!`)
     } catch (e) {
         console.error(`🛑 Web server could not start! ${e}`)
-    }
-    if (withSignalHandling) {
-        // Free up port
-        for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
-            process.on(signal, stopWebServer)
-        }
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,6 +1423,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
+
 "@types/yargs-parser@*":
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
@@ -1567,18 +1572,6 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.3, ajv@^6.12.4:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
-
-amqplib@^0.5.5:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/amqplib/-/amqplib-0.5.6.tgz#86a7850f4f39c568eaa0dd0300ef374e17941cf4"
-  integrity sha512-J4TR0WAMPBHN+tgTuhNsSObfM9eTVTZm/FNw0LyaGfbiLsBxqSameDNYpChUFXW4bnTKHDXy0ab+nuLhumnRrQ==
-  dependencies:
-    bitsyntax "~0.1.0"
-    bluebird "^3.5.2"
-    buffer-more-ints "~1.0.0"
-    readable-stream "1.x >=1.1.9"
-    safe-buffer "~5.1.2"
-    url-parse "~1.4.3"
 
 ansi-colors@^4.1.1:
   version "4.1.1"
@@ -1904,15 +1897,6 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bitsyntax@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/bitsyntax/-/bitsyntax-0.1.0.tgz#b0c59acef03505de5a2ed62a2f763c56ae1d6205"
-  integrity sha512-ikAdCnrloKmFOugAfxWws89/fPc+nw0OOG1IzIE72uSOg/A3cYptKCjSUhDTuj7fhsJtzkzlv7l3b8PzRHLN0Q==
-  dependencies:
-    buffer-more-ints "~1.0.0"
-    debug "~2.6.9"
-    safe-buffer "~5.1.2"
-
 bl@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
@@ -1921,11 +1905,6 @@ bl@^4.0.3:
     buffer "^5.5.0"
     inherits "^2.0.4"
     readable-stream "^3.4.0"
-
-bluebird@^3.5.2:
-  version "3.7.2"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
-  integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1991,11 +1970,6 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
-
-buffer-more-ints@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/buffer-more-ints/-/buffer-more-ints-1.0.0.tgz#ef4f8e2dddbad429ed3828a9c55d44f05c611422"
-  integrity sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==
 
 buffer-writer@2.0.0:
   version "2.0.0"
@@ -2082,15 +2056,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-celery-node@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/celery-node/-/celery-node-0.5.0.tgz#be5aade8e28652ca524945609acefc53a64e197b"
-  integrity sha512-rO8QWDaa/mwqKUYJTuA0rfRNACOXbokqlWNsGDstzOyRasxhjU+pWXubsQp52rSJTpXIA92hDiSv64nSTEmQNw==
-  dependencies:
-    amqplib "^0.5.5"
-    ioredis "^4.14.0"
-    uuid "^3.3.2"
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -2417,7 +2382,7 @@ dateformat@~1.0.4-1.2.3:
     get-stdin "^4.0.1"
     meow "^3.3.0"
 
-debug@^2.2.0, debug@^2.3.3, debug@^2.6.9, debug@~2.6.9:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -3643,7 +3608,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -3656,22 +3621,6 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
-
-ioredis@^4.14.0:
-  version "4.19.0"
-  resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.19.0.tgz#1ab3b36362cb3e805c4dbe90fbb7061182f94b63"
-  integrity sha512-7NIkLtpDQ/6WkEircBljnYz/E+kDQcwCJspfR504/tzyXJJQcHaSofMP6G0nuuLfDpOVnpS0AEwDrNIbW38HGg==
-  dependencies:
-    cluster-key-slot "^1.1.0"
-    debug "^4.1.1"
-    denque "^1.1.0"
-    lodash.defaults "^4.2.0"
-    lodash.flatten "^4.4.0"
-    p-map "^4.0.0"
-    redis-commands "1.6.0"
-    redis-errors "^1.2.0"
-    redis-parser "^3.0.0"
-    standard-as-callback "^2.0.1"
 
 ioredis@^4.19.2:
   version "4.19.2"
@@ -3974,11 +3923,6 @@ is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
-
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -5616,11 +5560,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-querystringify@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
-  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
-
 queue-microtask@^1.1.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
@@ -5693,16 +5632,6 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
-
-"readable-stream@1.x >=1.1.9":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.1.14.tgz#7cf4c54ef648e3813084c636dd2079e166c081d9"
-  integrity sha1-fPTFTvZI44EwhMY23SB54WbAgdk=
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "0.0.1"
-    string_decoder "~0.10.x"
 
 readable-stream@^2.0.0, readable-stream@^2.0.2, readable-stream@~2.3.6:
   version "2.3.7"
@@ -5910,11 +5839,6 @@ require-main-filename@^2.0.0:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
 
-requires-port@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
-  integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
-
 resolve-cwd@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-cwd/-/resolve-cwd-3.0.0.tgz#0f0075f1bb2544766cf73ba6a6e2adfebcb13f2d"
@@ -6093,7 +6017,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1, safe-buffer@~5.1.2:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
@@ -6530,11 +6454,6 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
-
-string_decoder@~0.10.x:
-  version "0.10.31"
-  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
-  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
 
 string_decoder@~1.1.1:
   version "1.1.1"
@@ -6990,14 +6909,6 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-parse@~1.4.3:
-  version "1.4.7"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"
-  integrity sha512-d3uaVyzDB9tQoSXFvuSUNFibTd9zxd2bkVrDRvF5TmvWWQwqE4lgYJ5m+x1DbecWkw+LK4RNl2CU1hHuOKPVlg==
-  dependencies:
-    querystringify "^2.1.1"
-    requires-port "^1.0.0"
-
 use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
@@ -7013,7 +6924,7 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.3.0:
+uuid@^8.3.0, uuid@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==


### PR DESCRIPTION
Few changes with this PR:

- Inline node-celery (MIT licensed), strip it to only what we need and fix all old typescript types. I removed all `ampq` code, and more importantly, removed the `AsyncResult` code, which you could not opt out. The original implementation would store a "event processed" notification in Redis for 24h after each task was completed. We had a similar situation with the python celery recently... and users complaining of running out of memory. Removing this in python-celery took our own Redis memory usage from 10GB to 10MB.
- Implement graceful shutdown on SIGTERM, SIGINT (ctrl+c), SIGHUP. Previously the app would just leave a process hanging in the background. Closes #20 
- Implement graceful shutdown for Node Celery. This was just not implemented.
- Node-celery was creating too many Redis connections. After the refactor and cleanup I got this down from 4 to 2. This will make heroku users happy.

Still WIP as I want to run a full E2E test on this, yet I have managed to royally bork up my python setup :/.

New tech debt:
- Add tests for celery (the [old ones](https://github.com/actumn/celery.node/tree/master/test) are using mocha & chai)