### PR TITLE
More plugin tests

### DIFF
--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -1,0 +1,25 @@
+import { setupPlugins } from '../plugins'
+import { defaultConfig } from '../server'
+import { Pool } from 'pg'
+import * as Redis from 'ioredis'
+import { PluginsServer } from '../types'
+
+jest.mock('../sql', () => ({
+    getPluginRows: jest.fn(async () => [{ id: 22, error: 'yeah' }]),
+    getPluginAttachmentRows: jest.fn(async () => [{ id: 22, error: 'yeah' }]),
+    getPluginConfigRows: jest.fn(async () => [{ id: 22, error: 'yeah' }]),
+}))
+
+let mockServer: PluginsServer
+beforeEach(async () => {
+    mockServer = {
+        ...defaultConfig,
+        db: new Pool(),
+        redis: new Redis('redis://mockmockmock/'),
+    }
+})
+
+test('setupPlugins', async () => {
+    // console.log('bla')
+    // await setupPlugins(mockServer)
+})

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -151,6 +151,11 @@ test('setupPlugins and runPlugins', async () => {
     expect(pluginConfig.vm).toBeDefined()
     expect(Object.keys(pluginConfig.vm!.methods)).toEqual(['processEvent'])
 
+    expect(setError).toHaveBeenCalled()
+    expect(setError.mock.calls[0][0]).toEqual(mockServer)
+    expect(setError.mock.calls[0][1]).toEqual(null)
+    expect(setError.mock.calls[0][2]).toEqual(pluginConfig)
+
     const processEvent = pluginConfig.vm!.methods['processEvent']
     const event = { event: '$test', properties: {}, team_id: 2 } as PluginEvent
     await processEvent(event)

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs'
 import * as os from 'os'
 import * as path from 'path'
 
-// mock functions that get data from posthgres and give them the right types
+// mock functions that get data from postgres and give them the right types
 jest.mock('../sql')
 type UnPromisify<F> = F extends (...args: infer A) => Promise<infer T> ? (...args: A) => T : never
 const getPluginRows = (s.getPluginRows as unknown) as jest.MockedFunction<UnPromisify<typeof s.getPluginRows>>

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -2,12 +2,74 @@ import { setupPlugins } from '../plugins'
 import { defaultConfig } from '../server'
 import { Pool } from 'pg'
 import * as Redis from 'ioredis'
-import { PluginsServer } from '../types'
+import { PluginConfig, PluginError, PluginsServer } from '../types'
+import { getPluginRows, getPluginAttachmentRows, getPluginConfigRows, setError } from '../sql'
+import * as AdmZip from 'adm-zip'
+import { PluginEvent } from 'posthog-plugins/src/types'
+
+function createArchive(name: string, indexJs: string): Buffer {
+    const zip = new AdmZip()
+    zip.addFile('testplugin/index.js', Buffer.alloc(indexJs.length, indexJs))
+    zip.addFile(
+        'testplugin/plugin.json',
+        new Buffer(
+            JSON.stringify({
+                name,
+                description: 'just for testing',
+                url: 'http://example.com/plugin',
+                config: {},
+                main: 'index.js',
+            })
+        )
+    )
+    return zip.toBuffer()
+}
+
+const plugin60 = {
+    id: 60,
+    name: 'posthog-maxmind-plugin',
+    description: 'Ingest GeoIP data via MaxMind',
+    url: 'https://www.npmjs.com/package/posthog-maxmind-plugin',
+    config_schema:
+        '{"localhostIP": {"hint": "Useful if testing locally", "name": "IP to use instead of 127.0.0.1", "type": "string", "order": 2, "default": "", "required": false}, "maxmindMmdb": {"hint": "The \\"GeoIP2 City\\" or \\"GeoLite2 City\\" database file", "name": "GeoIP .mddb database", "type": "attachment", "order": 1, "markdown": "Sign up for a [MaxMind.com](https://www.maxmind.com) account, download and extract the database and then upload the `.mmdb` file below", "required": true}}',
+    tag: '0.0.2',
+    archive: createArchive(
+        'posthog-maxmind-plugin',
+        'function processEvent (event) { if (event.properties) { event.properties.processed = true } return event }'
+    ),
+    from_json: false,
+    from_web: false,
+    error: null,
+}
+
+const pluginAttachment1 = {
+    id: 1,
+    key: 'maxmindMmdb',
+    content_type: 'application/octet-stream',
+    file_name: 'test.txt',
+    file_size: 4,
+    contents: 'test',
+    plugin_config_id: 39,
+    team_id: 2,
+}
+
+const pluginConfig39 = {
+    id: 39,
+    team_id: 2,
+    plugin_id: 60,
+    enabled: true,
+    order: 0,
+    config: '{"localhostIP": "94.224.212.175"}',
+    error: null,
+}
 
 jest.mock('../sql', () => ({
-    getPluginRows: jest.fn(async () => [{ id: 22, error: 'yeah' }]),
-    getPluginAttachmentRows: jest.fn(async () => [{ id: 22, error: 'yeah' }]),
-    getPluginConfigRows: jest.fn(async () => [{ id: 22, error: 'yeah' }]),
+    getPluginRows: jest.fn(async () => [plugin60]),
+    getPluginAttachmentRows: jest.fn(async () => [pluginAttachment1]),
+    getPluginConfigRows: jest.fn(async () => [pluginConfig39]),
+    setError: jest.fn((server: PluginsServer, pluginError: PluginError | null, pluginConfig: PluginConfig) => {
+        return true
+    }),
 }))
 
 let mockServer: PluginsServer
@@ -20,6 +82,39 @@ beforeEach(async () => {
 })
 
 test('setupPlugins', async () => {
-    // console.log('bla')
-    // await setupPlugins(mockServer)
+    const { plugins, pluginConfigs, pluginConfigsPerTeam, defaultConfigs } = await setupPlugins(mockServer)
+
+    expect(getPluginRows).toHaveBeenCalled()
+    expect(getPluginAttachmentRows).toHaveBeenCalled()
+    expect(getPluginConfigRows).toHaveBeenCalled()
+    expect(setError).toHaveBeenCalled()
+
+    expect(defaultConfigs).toEqual([])
+    expect(Array.from(plugins.entries())).toEqual([[60, plugin60]])
+    expect(Array.from(pluginConfigs.keys())).toEqual([39])
+
+    const pluginConfig = pluginConfigs.get(39)!
+    expect(pluginConfig.id).toEqual(pluginConfig39.id)
+    expect(pluginConfig.team_id).toEqual(pluginConfig39.team_id)
+    expect(pluginConfig.plugin_id).toEqual(pluginConfig39.plugin_id)
+    expect(pluginConfig.enabled).toEqual(pluginConfig39.enabled)
+    expect(pluginConfig.order).toEqual(pluginConfig39.order)
+    expect(pluginConfig.config).toEqual(pluginConfig39.config)
+    expect(pluginConfig.error).toEqual(pluginConfig39.error)
+
+    expect(pluginConfig.plugin).toEqual(plugin60)
+    expect(pluginConfig.attachments).toEqual({
+        maxmindMmdb: {
+            content_type: pluginAttachment1.content_type,
+            file_name: pluginAttachment1.file_name,
+            contents: pluginAttachment1.contents,
+        },
+    })
+    expect(Object.keys(pluginConfig.vm!.methods)).toEqual(['processEvent'])
+
+    const processEvent = pluginConfig.vm!.methods['processEvent']
+    const event = { event: '$test', properties: {} } as PluginEvent
+    await processEvent(event)
+
+    expect(event.properties!['processed']).toEqual(true)
 })

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -251,3 +251,22 @@ test('plugin with broken plugin.json does not do much', async () => {
     expect(setError.mock.calls[0][1]!.time).toBeDefined()
     expect(pluginConfigs.get(39)!.vm).toEqual(null)
 })
+
+test('plugin with http urls must have an archive', async () => {
+    // silence some spam
+    console.log = jest.fn()
+    console.error = jest.fn()
+
+    getPluginRows.mockReturnValueOnce([{ ...plugin60, archive: null }])
+    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+
+    const { pluginConfigs } = await setupPlugins(mockServer)
+
+    expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
+    expect(setError).toHaveBeenCalled()
+    expect(setError.mock.calls[0][0]).toEqual(mockServer)
+    expect(setError.mock.calls[0][1]!.message).toEqual('Un-downloaded remote plugins not supported!')
+    expect(setError.mock.calls[0][1]!.time).toBeDefined()
+    expect(pluginConfigs.get(39)!.vm).toEqual(null)
+})

--- a/src/__tests__/plugins.test.ts
+++ b/src/__tests__/plugins.test.ts
@@ -270,3 +270,22 @@ test('plugin with http urls must have an archive', async () => {
     expect(setError.mock.calls[0][1]!.time).toBeDefined()
     expect(pluginConfigs.get(39)!.vm).toEqual(null)
 })
+
+test("plugin with broken archive doesn't load", async () => {
+    // silence some spam
+    console.log = jest.fn()
+    console.error = jest.fn()
+
+    getPluginRows.mockReturnValueOnce([{ ...plugin60, archive: Buffer.from('this is not a zip') }])
+    getPluginConfigRows.mockReturnValueOnce([pluginConfig39])
+    getPluginAttachmentRows.mockReturnValueOnce([pluginAttachment1])
+
+    const { pluginConfigs } = await setupPlugins(mockServer)
+
+    expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
+    expect(setError).toHaveBeenCalled()
+    expect(setError.mock.calls[0][0]).toEqual(mockServer)
+    expect(setError.mock.calls[0][1]!.message).toEqual('Could not read archive as .zip or .tgz')
+    expect(setError.mock.calls[0][1]!.time).toBeDefined()
+    expect(pluginConfigs.get(39)!.vm).toEqual(null)
+})

--- a/src/__tests__/sql.test.ts
+++ b/src/__tests__/sql.test.ts
@@ -1,0 +1,100 @@
+import { getPluginAttachmentRows, getPluginConfigRows, getPluginRows, setError } from '../sql'
+import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginsServer } from '../types'
+import { defaultConfig } from '../server'
+import { Pool } from 'pg'
+import * as Redis from 'ioredis'
+
+let mockServer: PluginsServer
+beforeEach(async () => {
+    mockServer = {
+        ...defaultConfig,
+        db: new Pool(),
+        redis: new Redis('redis://mockmockmock/'),
+    }
+})
+
+test('getPluginAttachmentRows', async () => {
+    const pluginAttachment1: PluginAttachmentDB = {
+        id: 1,
+        key: 'maxmindMmdb',
+        content_type: 'application/octet-stream',
+        file_name: 'test.txt',
+        file_size: 4,
+        contents: Buffer.from('test'),
+        plugin_config_id: 39,
+        team_id: 2,
+    }
+    mockServer.db.query = jest.fn((query, params) => ({
+        rows: [pluginAttachment1],
+    })) as any
+    const rows = await getPluginAttachmentRows(mockServer)
+    expect(rows).toEqual([pluginAttachment1])
+    expect(mockServer.db.query).toHaveBeenCalledWith(
+        "SELECT * FROM posthog_pluginattachment WHERE plugin_config_id in (SELECT id FROM posthog_pluginconfig WHERE enabled='t')"
+    )
+})
+
+test('getPluginConfigRows', async () => {
+    const pluginConfig39: PluginConfig = {
+        id: 39,
+        team_id: 2,
+        plugin_id: 60,
+        enabled: true,
+        order: 0,
+        config: {},
+        error: undefined,
+    }
+    mockServer.db.query = jest.fn((query, params) => ({
+        rows: [pluginConfig39],
+    })) as any
+    const rows = await getPluginConfigRows(mockServer)
+    expect(rows).toEqual([pluginConfig39])
+    expect(mockServer.db.query).toHaveBeenCalledWith("SELECT * FROM posthog_pluginconfig WHERE enabled='t'")
+})
+
+test('getPluginRows', async () => {
+    const plugin60: Plugin = {
+        id: 60,
+        name: 'posthog-test-plugin',
+        description: 'Ingest GeoIP data via MaxMind',
+        url: 'https://www.npmjs.com/package/posthog-maxmind-plugin',
+        config_schema: {},
+        tag: '0.0.2',
+        archive: null,
+        error: undefined,
+    }
+    mockServer.db.query = jest.fn((query, params) => ({
+        rows: [plugin60],
+    })) as any
+    const rows = await getPluginRows(mockServer)
+    expect(rows).toEqual([plugin60])
+    expect(mockServer.db.query).toHaveBeenCalledWith(
+        "SELECT * FROM posthog_plugin WHERE id in (SELECT plugin_id FROM posthog_pluginconfig WHERE enabled='t' GROUP BY plugin_id)"
+    )
+})
+
+test('setError', async () => {
+    const pluginConfig39: PluginConfig = {
+        id: 39,
+        team_id: 2,
+        plugin_id: 60,
+        enabled: true,
+        order: 0,
+        config: {},
+        error: undefined,
+    }
+    mockServer.db.query = jest.fn() as any
+
+    await setError(mockServer, null, pluginConfig39)
+    expect(mockServer.db.query).toHaveBeenCalledWith('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
+        null,
+        pluginConfig39.id,
+    ])
+
+    const pluginError: PluginError = { message: 'error happened', time: 'now' }
+    await setError(mockServer, pluginError, pluginConfig39)
+    expect(mockServer.db.query).toHaveBeenCalledWith('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
+        pluginError,
+        pluginConfig39.id,
+    ])
+})

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,5 +1,6 @@
 import { PluginConfig, PluginError, PluginsServer } from './types'
 import { PluginEvent } from 'posthog-plugins'
+import { setError } from './sql'
 
 export async function processError(
     server: PluginsServer,
@@ -23,9 +24,9 @@ export async function processError(
                   event: event,
               }
 
-    await server.db.query('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [errorJson, pluginConfig.id])
+    await setError(server, errorJson, pluginConfig)
 }
 
 export async function clearError(server: PluginsServer, pluginConfig: PluginConfig): Promise<void> {
-    await server.db.query('UPDATE posthog_pluginconfig SET error = NULL WHERE id = $1', [pluginConfig.id])
+    await setError(server, null, pluginConfig)
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -105,6 +105,10 @@ export async function setupPlugins(
 async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Promise<void> {
     const { plugin } = pluginConfig
 
+    if (!plugin) {
+        return
+    }
+
     if (plugin.url.startsWith('file:')) {
         const pluginPath = path.resolve(server.BASE_DIR, plugin.url.substring(5))
         const configPath = path.resolve(pluginPath, 'plugin.json')
@@ -157,6 +161,7 @@ async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Pr
                 config = JSON.parse(json)
             } catch (error) {
                 await processError(server, pluginConfig, `Can not load plugin.json for plugin "${plugin.name}"`)
+                return
             }
         }
 
@@ -196,11 +201,11 @@ export async function runPlugins(server: PluginsServer, event: PluginEvent): Pro
                 try {
                     returnedEvent = (await processEvent(returnedEvent)) || null
                     const ms = Math.round((performance.now() - startTime) * 1000) / 1000
-                    logTime(pluginConfig.plugin.name, ms)
+                    logTime(pluginConfig.plugin?.name || 'noname', ms)
                 } catch (error) {
                     await processError(server, pluginConfig, error, returnedEvent)
                     const ms = Math.round((performance.now() - startTime) * 1000) / 1000
-                    logTime(pluginConfig.plugin.name, ms, true)
+                    logTime(pluginConfig.plugin?.name || 'noname', ms, true)
                 }
             }
 

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -1,15 +1,7 @@
 import * as path from 'path'
 import * as fs from 'fs'
 import { createPluginConfigVM, prepareForRun } from './vm'
-import {
-    PluginsServer,
-    Plugin,
-    PluginConfig,
-    PluginJsonConfig,
-    PluginId,
-    PluginConfigId,
-    TeamId,
-} from './types'
+import { PluginsServer, Plugin, PluginConfig, PluginJsonConfig, PluginId, PluginConfigId, TeamId } from './types'
 import { PluginEvent, PluginAttachment } from 'posthog-plugins'
 import { clearError, processError } from './error'
 import { getFileFromArchive } from './utils'
@@ -22,7 +14,14 @@ const pluginConfigs = new Map<PluginConfigId, PluginConfig>()
 const pluginConfigsPerTeam = new Map<TeamId, PluginConfig[]>()
 let defaultConfigs: PluginConfig[] = []
 
-export async function setupPlugins(server: PluginsServer): Promise<void> {
+export async function setupPlugins(
+    server: PluginsServer
+): Promise<{
+    plugins: Map<PluginId, Plugin>
+    pluginConfigs: Map<PluginConfigId, PluginConfig>
+    pluginConfigsPerTeam: Map<TeamId, PluginConfig[]>
+    defaultConfigs: PluginConfig[]
+}> {
     const pluginRows = await getPluginRows(server)
     const foundPlugins = new Map<number, boolean>()
     for (const row of pluginRows) {
@@ -93,6 +92,13 @@ export async function setupPlugins(server: PluginsServer): Promise<void> {
             pluginConfigsPerTeam.set(teamId, [...(pluginConfigsPerTeam.get(teamId) || []), ...defaultConfigs])
             pluginConfigsPerTeam.get(teamId)?.sort((a, b) => a.id - b.id)
         }
+    }
+
+    return {
+        plugins,
+        pluginConfigs,
+        pluginConfigsPerTeam,
+        defaultConfigs,
     }
 }
 

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -1,29 +1,30 @@
 import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginsServer } from './types'
 
-export async function getPluginRows(server: PluginsServer) {
+export async function getPluginRows(server: PluginsServer): Promise<Plugin[]> {
     const { rows: pluginRows }: { rows: Plugin[] } = await server.db.query(
         "SELECT * FROM posthog_plugin WHERE id in (SELECT plugin_id FROM posthog_pluginconfig WHERE enabled='t' GROUP BY plugin_id)"
     )
     return pluginRows
 }
 
-export async function getPluginAttachmentRows(server: PluginsServer) {
+export async function getPluginAttachmentRows(server: PluginsServer): Promise<PluginAttachmentDB[]> {
     const { rows }: { rows: PluginAttachmentDB[] } = await server.db.query(
         "SELECT * FROM posthog_pluginattachment WHERE plugin_config_id in (SELECT id FROM posthog_pluginconfig WHERE enabled='t')"
     )
     return rows
 }
 
-export async function getPluginConfigRows(server: PluginsServer) {
+export async function getPluginConfigRows(server: PluginsServer): Promise<PluginConfig[]> {
     const { rows }: { rows: PluginConfig[] } = await server.db.query(
         "SELECT * FROM posthog_pluginconfig WHERE enabled='t'"
     )
     return rows
 }
 
-export async function setError(server: PluginsServer, pluginError: PluginError | null, pluginConfig: PluginConfig) {
-    await server.db.query('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
-        pluginError,
-        pluginConfig.id,
-    ])
+export async function setError(
+    server: PluginsServer,
+    pluginError: PluginError | null,
+    pluginConfig: PluginConfig
+): Promise<void> {
+    await server.db.query('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [pluginError, pluginConfig.id])
 }

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -1,0 +1,29 @@
+import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginsServer } from './types'
+
+export async function getPluginRows(server: PluginsServer) {
+    const { rows: pluginRows }: { rows: Plugin[] } = await server.db.query(
+        "SELECT * FROM posthog_plugin WHERE id in (SELECT plugin_id FROM posthog_pluginconfig WHERE enabled='t' GROUP BY plugin_id)"
+    )
+    return pluginRows
+}
+
+export async function getPluginAttachmentRows(server: PluginsServer) {
+    const { rows }: { rows: PluginAttachmentDB[] } = await server.db.query(
+        "SELECT * FROM posthog_pluginattachment WHERE plugin_config_id in (SELECT id FROM posthog_pluginconfig WHERE enabled='t')"
+    )
+    return rows
+}
+
+export async function getPluginConfigRows(server: PluginsServer) {
+    const { rows }: { rows: PluginConfig[] } = await server.db.query(
+        "SELECT * FROM posthog_pluginconfig WHERE enabled='t'"
+    )
+    return rows
+}
+
+export async function setError(server: PluginsServer, pluginError: PluginError | null, pluginConfig: PluginConfig) {
+    await server.db.query('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
+        pluginError,
+        pluginConfig.id,
+    ])
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,7 @@ export interface Plugin {
 export interface PluginConfig {
     id: PluginConfigId
     team_id: TeamId
-    plugin: Plugin
+    plugin?: Plugin
     plugin_id: PluginId
     enabled: boolean
     order: number
@@ -71,6 +71,7 @@ export interface PluginAttachmentDB {
     plugin_config_id: PluginConfigId
     key: string
     content_type: string
+    file_size: number | null
     file_name: string
     contents: Buffer | null
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,10 +74,23 @@ export async function getFileFromTGZ(archive: Buffer, file: string): Promise<str
 export function getFileFromZip(archive: Buffer, file: string): string | null {
     const zip = new AdmZip(archive)
     const zipEntries = zip.getEntries() // an array of ZipEntry records
-    const root = zipEntries[0].entryName
-    const fileData = zip.getEntry(`${root}${file}`)
+    let fileData
+
+    if (zipEntries[0].entryName.endsWith('/')) {
+        // if first entry is `pluginfolder/` (a folder!)
+        const root = zipEntries[0].entryName
+        fileData = zip.getEntry(`${root}${file}`)
+    } else {
+        // if first entry is `pluginfolder/index.js` (or whatever file)
+        const rootPathArray = zipEntries[0].entryName.split('/')
+        rootPathArray.pop()
+        const root = rootPathArray.join('/')
+        fileData = zip.getEntry(`${root}/${file}`)
+    }
+
     if (fileData) {
         return fileData.getData().toString()
     }
+
     return null
 }

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -20,7 +20,11 @@ export function createPluginConfigVM(
     vm.freeze(fetch, 'fetch')
     vm.freeze(
         {
-            cache: createCache(server, pluginConfig.plugin.name, pluginConfig.team_id),
+            cache: createCache(
+                server,
+                pluginConfig.plugin?.name || pluginConfig.plugin_id.toString(),
+                pluginConfig.team_id
+            ),
             config: pluginConfig.config,
             attachments: pluginConfig.attachments,
         },


### PR DESCRIPTION
- Tests loading plugins, plugin config and plugin attachments from postgres
- Tests running these plugins
- Test loading plugins from the local filesystem
- Test various failure scenarios

Missing from here:
- Tests for loading global plugins (this doesn't work now and will be rewritten anyway)
- Tests for loading lib.js files (will be deprecated pretty soon)