### PR TITLE
Move tests to their own folder

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,5 +4,5 @@ module.exports = {
     clearMocks: true,
     coverageProvider: 'v8',
     setupFilesAfterEnv: ['./jest.setup.pg-mock.js', './jest.setup.redis-mock.js', './jest.setup.fetch-mock.js'],
-    testMatch: ['<rootDir>/src/**/__tests__/**/*.test.ts'],
+    testMatch: ['<rootDir>/tests/**/*.test.ts'],
 }

--- a/tests/helpers/plugins.ts
+++ b/tests/helpers/plugins.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginAttachmentDB, PluginConfig } from '../../types'
+import { Plugin, PluginAttachmentDB, PluginConfig } from '../../src/types'
 import fs from 'fs'
 import path from 'path'
 import os from 'os'

--- a/tests/helpers/sqlMock.ts
+++ b/tests/helpers/sqlMock.ts
@@ -1,4 +1,4 @@
-import * as s from '../../sql'
+import * as s from '../../src/sql'
 
 // mock functions that get data from postgres and give them the right types
 type UnPromisify<F> = F extends (...args: infer A) => Promise<infer T> ? (...args: A) => T : never

--- a/tests/piscina.test.ts
+++ b/tests/piscina.test.ts
@@ -1,11 +1,11 @@
-import { defaultConfig } from '../../server'
-import { makePiscina } from '../piscina'
+import { defaultConfig } from '../src/server'
+import { makePiscina } from '../src/worker/piscina'
 import { PluginEvent } from 'posthog-plugins/src/types'
 import { performance } from 'perf_hooks'
-import { mockJestWithIndex } from '../../__tests__/helpers/plugins'
+import { mockJestWithIndex } from './helpers/plugins'
 import * as os from 'os'
 
-jest.mock('../../sql')
+jest.mock('../src/sql')
 jest.setTimeout(300000) // 300 sec timeout
 
 function processOneEvent(processEvent: (event: PluginEvent) => Promise<PluginEvent>): Promise<PluginEvent> {

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -1,6 +1,6 @@
-import { runPlugins, setupPlugins } from '../plugins'
-import { createServer } from '../server'
-import { PluginsServer } from '../types'
+import { runPlugins, setupPlugins } from '../src/plugins'
+import { createServer } from '../src/server'
+import { PluginsServer } from '../src/types'
 import { PluginEvent } from 'posthog-plugins/src/types'
 import {
     mockPluginTempFolder,
@@ -10,7 +10,7 @@ import {
     pluginConfig39,
 } from './helpers/plugins'
 import { getPluginAttachmentRows, getPluginConfigRows, getPluginRows, setError } from './helpers/sqlMock'
-jest.mock('../sql')
+jest.mock('../src/sql')
 
 let mockServer: PluginsServer
 beforeEach(async () => {

--- a/tests/queue.test.ts
+++ b/tests/queue.test.ts
@@ -1,8 +1,8 @@
-import { startQueue } from '../queue'
-import { createServer, defaultConfig } from '../../server'
-import { PluginsServer } from '../../types'
-import Client from '../../celery/client'
-import { runPlugins } from '../../plugins'
+import { startQueue } from '../src/worker/queue'
+import { createServer, defaultConfig } from '../src/server'
+import { PluginsServer } from '../src/types'
+import Client from '../src/celery/client'
+import { runPlugins } from '../src/plugins'
 
 function advanceOneTick() {
     return new Promise((resolve) => process.nextTick(resolve))

--- a/tests/sql.test.ts
+++ b/tests/sql.test.ts
@@ -1,6 +1,6 @@
-import { getPluginAttachmentRows, getPluginConfigRows, getPluginRows, setError } from '../sql'
-import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginsServer } from '../types'
-import { createServer } from '../server'
+import { getPluginAttachmentRows, getPluginConfigRows, getPluginRows, setError } from '../src/sql'
+import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginsServer } from '../src/types'
+import { createServer } from '../src/server'
 
 let mockServer: PluginsServer
 beforeEach(async () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,4 +1,4 @@
-import { getFileFromTGZ, getFileFromZip, getFileFromArchive, bufferToStream } from '../utils'
+import { getFileFromTGZ, getFileFromZip, getFileFromArchive, bufferToStream } from '../src/utils'
 
 // .zip in Base64: github repo posthog/helloworldplugin
 const zip =

--- a/tests/vm.test.ts
+++ b/tests/vm.test.ts
@@ -1,7 +1,7 @@
-import { createPluginConfigVM, prepareForRun } from '../vm'
-import { PluginConfig, PluginsServer, Plugin } from '../types'
+import { createPluginConfigVM, prepareForRun } from '../src/vm'
+import { PluginConfig, PluginsServer, Plugin } from '../src/types'
 import { PluginEvent } from 'posthog-plugins'
-import { createServer, defaultConfig } from '../server'
+import { createServer, defaultConfig } from '../src/server'
 import * as fetch from 'node-fetch'
 
 const defaultEvent = {


### PR DESCRIPTION
Move all tests under `<root>/tests`. Splitting all of them between two folders seemed like a good idea at first, but turns out to be quite impractical while working. Might be worth revisiting when we grow to 100+ .ts files.