### PR TITLE
Add `incr` and `expire` to `meta.cache`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "pg": "^8.4.2",
         "piscina": "^2.1.0",
         "posthog-js-lite": "^0.0.5",
-        "posthog-plugins": "^0.2.3",
+        "posthog-plugins": "^0.2.4",
         "tar-stream": "^2.1.4",
         "uuid": "^8.3.1",
         "vm2": "^3.9.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "pg": "^8.4.2",
         "piscina": "^2.1.0",
         "posthog-js-lite": "^0.0.5",
-        "posthog-plugins": "^0.2.4",
+        "posthog-plugins": "0.2.4",
         "tar-stream": "^2.1.4",
         "uuid": "^8.3.1",
         "vm2": "^3.9.2",

--- a/src/extensions/cache.ts
+++ b/src/extensions/cache.ts
@@ -4,8 +4,12 @@ import { CacheExtension } from 'posthog-plugins'
 export function createCache(server: PluginsServer, pluginName: string, teamId: number): CacheExtension {
     const getKey = (key: string) => `@plugin/${pluginName}/${typeof teamId === 'undefined' ? '@all' : teamId}/${key}`
     return {
-        set: function (key: string, value: unknown): void {
-            server.redis.set(getKey(key), JSON.stringify(value))
+        set: async function (key: string, value: unknown, ttlSeconds?: number): Promise<void> {
+            if (ttlSeconds) {
+                await server.redis.set(getKey(key), JSON.stringify(value), 'EX', ttlSeconds)
+            } else {
+                await server.redis.set(getKey(key), JSON.stringify(value))
+            }
         },
         get: async function (key: string, defaultValue: unknown): Promise<unknown> {
             const value = await server.redis.get(getKey(key))
@@ -17,6 +21,12 @@ export function createCache(server: PluginsServer, pluginName: string, teamId: n
             } catch (e) {
                 return null
             }
+        },
+        incr: async function (key: string): Promise<number> {
+            return await server.redis.incr(getKey(key))
+        },
+        expire: async function (key: string, ttlSeconds: number): Promise<boolean> {
+            return (await server.redis.expire(getKey(key), ttlSeconds)) === 1
         },
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5484,7 +5484,7 @@ posthog-js-lite@^0.0.5:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.5.tgz#984a619190d1c4ef003cb81194d0a6276491d2e8"
   integrity sha512-xHVZ9qbBdoqK7G1JVA4k6nheWu50aiEwjJIPQw7Zhi705aX5wr2W8zxdmvtadeEE5qbJNg+/uZ7renOQoqcbJw==
 
-posthog-plugins@^0.2.4:
+posthog-plugins@0.2.4:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/posthog-plugins/-/posthog-plugins-0.2.4.tgz#e4050795e7e14ada29de301f6b15e900bbad2ce8"
   integrity sha512-M+t4Juu/Vr/GSRwjNDXunarPck7YXEqF6AKb4u5tRrOBI2VIyHjJiLtsIj5SwVsl4VKpMyyfahV/0No7ByT3TA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5484,10 +5484,10 @@ posthog-js-lite@^0.0.5:
   resolved "https://registry.yarnpkg.com/posthog-js-lite/-/posthog-js-lite-0.0.5.tgz#984a619190d1c4ef003cb81194d0a6276491d2e8"
   integrity sha512-xHVZ9qbBdoqK7G1JVA4k6nheWu50aiEwjJIPQw7Zhi705aX5wr2W8zxdmvtadeEE5qbJNg+/uZ7renOQoqcbJw==
 
-posthog-plugins@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/posthog-plugins/-/posthog-plugins-0.2.3.tgz#8f57d63c9fde9302e24c5c954cb5f11a370c4b2f"
-  integrity sha512-4YeRNa1h8QptGVQA+vkchgrwcAixrY1GhsAPgv/WFmSMIe0pFSi/bsriZUAQceSzVi0MCOuzqU3YW9rDNLsSYg==
+posthog-plugins@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/posthog-plugins/-/posthog-plugins-0.2.4.tgz#e4050795e7e14ada29de301f6b15e900bbad2ce8"
+  integrity sha512-M+t4Juu/Vr/GSRwjNDXunarPck7YXEqF6AKb4u5tRrOBI2VIyHjJiLtsIj5SwVsl4VKpMyyfahV/0No7ByT3TA==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
- Adds `incr`. With max 100 concurrent events per worker, the `await cache.set('counter', await cache.get('counter', 0) + 1)` pattern no longer works, so this makes a lot of sense.
- Expiration is also a useful thing for a cache, so added it as well.