### PR TITLE
Reducer default task concurrency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-plugin-server",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "PostHog Plugin Server",
     "types": "dist/src/index.d.ts",
     "main": "dist/src/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,7 +15,7 @@ export function getDefaultConfig(): PluginsServerConfig {
         WEB_PORT: 3008,
         WEB_HOSTNAME: '0.0.0.0',
         WORKER_CONCURRENCY: 0, // use all cores
-        TASKS_PER_WORKER: 100,
+        TASKS_PER_WORKER: 10,
         LOG_LEVEL: LogLevel.Info,
     }
 }


### PR DESCRIPTION
Reducing the nr of async tasks a worker can do in parallel to `10` from `100`.

Seeing 100 queued async tasks start in parallel on the cheap heroku dyno makes me think:
- what if these also adds 100 redis connections?
- what if this runs out of memory running that many things in parallel?

When we enable batching, running 100 batches in parallel in one thread is probably too much, even if it makes for nicer numbers in the benchmarks. 