### PR TITLE
Process shutdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-plugin-server",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "description": "PostHog Plugin Server",
     "types": "dist/src/index.d.ts",
     "main": "dist/src/index.js",

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@ import { PluginEvent } from 'posthog-plugins'
 import { defaultConfig } from './config'
 import Piscina from 'piscina'
 import * as Sentry from '@sentry/node'
+import { delay } from './utils'
 
 export async function createServer(
     config: Partial<PluginsServerConfig> = {}
@@ -86,7 +87,7 @@ export async function startPluginsServer(
         await closeServer()
 
         // wait an extra second for any misc async task to finish
-        await new Promise((resolve) => setTimeout(resolve, 1000))
+        await delay(1000)
     }
 
     for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP']) {
@@ -115,6 +116,8 @@ export async function startPluginsServer(
             if (channel === server!.PLUGINS_RELOAD_PUBSUB_CHANNEL) {
                 console.log('⚡ Reloading plugins!')
                 await queue?.stop()
+                // wait an extra second for any misc async task to finish
+                await delay(1000)
                 await piscina?.destroy()
 
                 piscina = makePiscina(serverConfig!)

--- a/src/server.ts
+++ b/src/server.ts
@@ -83,7 +83,7 @@ export async function startPluginsServer(
         if (job) {
             schedule.cancelJob(job)
         }
-        await piscina?.destroy()
+        await stopPiscina(piscina!)
         await closeServer()
 
         // wait an extra second for any misc async task to finish
@@ -116,10 +116,7 @@ export async function startPluginsServer(
             if (channel === server!.PLUGINS_RELOAD_PUBSUB_CHANNEL) {
                 console.log('⚡ Reloading plugins!')
                 await queue?.stop()
-                // wait an extra second for any misc async task to finish
-                await delay(1000)
-                await piscina?.destroy()
-
+                await stopPiscina(piscina!)
                 piscina = makePiscina(serverConfig!)
                 queue = startQueue(server!, processEvent)
             }
@@ -139,4 +136,11 @@ export async function startPluginsServer(
 
         process.exit(1)
     }
+}
+
+export async function stopPiscina(piscina: Piscina): Promise<void> {
+    // Wait two seconds for any running workers to stop.
+    // TODO: better "wait until everything is done"
+    await delay(2000)
+    await piscina.destroy()
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -124,3 +124,9 @@ export function cloneObject<T extends any | any[]>(obj: T): T {
     }
     return clone as T
 }
+
+export function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms)
+    })
+}

--- a/tests/vm.test.ts
+++ b/tests/vm.test.ts
@@ -3,6 +3,7 @@ import { PluginConfig, PluginsServer, Plugin } from '../src/types'
 import { PluginEvent } from 'posthog-plugins'
 import { createServer } from '../src/server'
 import * as fetch from 'node-fetch'
+import { delay } from '../src/utils'
 
 const defaultEvent = {
     distinct_id: 'my_id',
@@ -412,7 +413,7 @@ test('meta.cache expire', async () => {
     await vm.methods.processEvent(event)
     expect(event.properties!['counter']).toEqual(2)
 
-    await new Promise((resolve) => setTimeout(resolve, 1200))
+    await delay(1200)
 
     await vm.methods.processEvent(event)
     expect(event.properties!['counter']).toEqual(1)
@@ -440,7 +441,7 @@ test('meta.cache set ttl', async () => {
     await vm.methods.processEvent(event)
     expect(event.properties!['counter']).toEqual(2)
 
-    await new Promise((resolve) => setTimeout(resolve, 1200))
+    await delay(1200)
 
     await vm.methods.processEvent(event)
     expect(event.properties!['counter']).toEqual(1)


### PR DESCRIPTION
- Add some error handling to the queue
- Wait 2 sec before shutting down workers on reload (needs a better solution)
- Refactor `setTimeout` promises do `delay` util