### PR TITLE
Scheduled tasks

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,11 +1,11 @@
-import { PluginConfig, PluginError, PluginsServer } from './types'
+import { PluginConfig, PluginConfigId, PluginError, PluginsServer } from './types'
 import { PluginEvent } from 'posthog-plugins'
 import { setError } from './sql'
 import * as Sentry from '@sentry/node'
 
 export async function processError(
     server: PluginsServer,
-    pluginConfig: PluginConfig,
+    pluginConfig: PluginConfig | PluginConfigId,
     error: Error | string,
     event?: PluginEvent | null
 ): Promise<void> {
@@ -29,6 +29,6 @@ export async function processError(
     await setError(server, errorJson, pluginConfig)
 }
 
-export async function clearError(server: PluginsServer, pluginConfig: PluginConfig): Promise<void> {
+export async function clearError(server: PluginsServer, pluginConfig: PluginConfig | PluginConfigId): Promise<void> {
     await setError(server, null, pluginConfig)
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -76,11 +76,9 @@ export async function setupPlugins(server: PluginsServer): Promise<void> {
     // gather runEvery* tasks into a schedule
     server.pluginSchedule = { runEveryMinute: [], runEveryHour: [], runEveryDay: [] }
     for (const [id, pluginConfig] of server.pluginConfigs) {
-        if (pluginConfig.vm?.tasks && Object.keys(pluginConfig.vm?.tasks).length > 0) {
-            for (const [taskName, task] of Object.entries(pluginConfig.vm.tasks)) {
-                if (task && taskName in server.pluginSchedule) {
-                    server.pluginSchedule[taskName].push(pluginConfig.id)
-                }
+        for (const [taskName, task] of Object.entries(pluginConfig.vm?.tasks ?? {})) {
+            if (task && taskName in server.pluginSchedule) {
+                server.pluginSchedule[taskName].push(pluginConfig.id)
             }
         }
     }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -82,10 +82,7 @@ export async function setupPlugins(server: PluginsServer): Promise<void> {
         if (pluginConfig.vm?.tasks && Object.keys(pluginConfig.vm?.tasks).length > 0) {
             for (const [taskName, task] of Object.entries(pluginConfig.vm.tasks)) {
                 if (task && taskName in server.pluginSchedule) {
-                    server.pluginSchedule[taskName].push({
-                        pluginConfig,
-                        task,
-                    })
+                    server.pluginSchedule[taskName].push(pluginConfig.id)
                 }
             }
         }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -93,7 +93,7 @@ async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Pr
     }
 
     try {
-        if (plugin.url.startsWith('file:')) {
+        if (plugin.url?.startsWith('file:')) {
             const pluginPath = path.resolve(server.BASE_DIR, plugin.url.substring(5))
             const configPath = path.resolve(pluginPath, 'plugin.json')
 
@@ -170,7 +170,11 @@ async function loadPlugin(server: PluginsServer, pluginConfig: PluginConfig): Pr
                 await processError(server, pluginConfig, `Could not load index.js for plugin "${plugin.name}"!`)
             }
         } else {
-            await processError(server, pluginConfig, 'Un-downloaded remote plugins not supported!')
+            await processError(
+                server,
+                pluginConfig,
+                `Un-downloaded remote plugins not supported! Plugin: "${plugin.name}"`
+            )
         }
     } catch (error) {
         await processError(server, pluginConfig, error)

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -268,6 +268,14 @@ export async function runPluginsOnBatch(server: PluginsServer, batch: PluginEven
     return allReturnedEvents
 }
 
+export async function runPluginTask(server: PluginsServer, taskName: string, pluginConfigId: number): Promise<any> {
+    const startTime = performance.now()
+    const pluginConfig = server.pluginConfigs.get(pluginConfigId)
+    const task = pluginConfig?.vm?.tasks[taskName]
+    const response = await task?.exec()
+    return response
+}
+
 function getPluginsForTeam(server: PluginsServer, teamId: number): PluginConfig[] {
     return server.pluginConfigsPerTeam.get(teamId) || server.defaultConfigs
 }

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -68,15 +68,12 @@ export async function setupPlugins(server: PluginsServer): Promise<void> {
     for (const [id, pluginConfig] of server.pluginConfigs) {
         if (!foundPluginConfigs.has(id)) {
             server.pluginConfigs.delete(id)
-            return
-        }
-
-        if (!pluginConfig.vm) {
+        } else if (!pluginConfig.vm) {
             await loadPlugin(server, pluginConfig)
         }
     }
 
-    // gather runEvery tasks into a schedule
+    // gather runEvery* tasks into a schedule
     server.pluginSchedule = { runEveryMinute: [], runEveryHour: [], runEveryDay: [] }
     for (const [id, pluginConfig] of server.pluginConfigs) {
         if (pluginConfig.vm?.tasks && Object.keys(pluginConfig.vm?.tasks).length > 0) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -115,6 +115,7 @@ export async function startPluginsServer(
         runEveryDayJob && schedule.cancelJob(runEveryDayJob)
         runEveryHourJob && schedule.cancelJob(runEveryHourJob)
         runEveryMinuteJob && schedule.cancelJob(runEveryMinuteJob)
+        await waitForTasksToFinish(server!)
         await stopPiscina(piscina!)
         await closeServer()
 
@@ -148,6 +149,7 @@ export async function startPluginsServer(
             if (channel === server!.PLUGINS_RELOAD_PUBSUB_CHANNEL) {
                 console.info('⚡ Reloading plugins!')
                 await queue?.stop()
+                await waitForTasksToFinish(server!)
                 await stopPiscina(piscina!)
                 piscina = makePiscina(serverConfig!)
                 queue = startQueue(server!, processEvent)
@@ -221,4 +223,8 @@ export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskN
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
     }
+}
+
+export async function waitForTasksToFinish(server: PluginsServer) {
+    return Promise.all(Object.values(server.pluginSchedulePromises).flatMap(Object.values))
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -226,5 +226,9 @@ export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskN
 }
 
 export async function waitForTasksToFinish(server: PluginsServer) {
-    return Promise.all(Object.values(server.pluginSchedulePromises).flatMap(Object.values))
+    const activePromises = Object.values(server.pluginSchedulePromises)
+        .map(Object.values)
+        .flat()
+        .filter((a) => a)
+    return Promise.all(activePromises)
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -200,7 +200,7 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
     await piscina.destroy()
 }
 
-function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskName: string) {
+export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskName: string) {
     const runTask = (pluginConfigId: PluginConfigId) =>
         piscina!.runTask({ task: `tasks.${taskName}`, args: { pluginConfigId } })
 
@@ -218,7 +218,7 @@ function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskName: st
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
             .catch(async (error) => {
-                await processError(server, server.pluginConfigs.get(pluginConfigId)!, error)
+                await processError(server, pluginConfigId, error)
                 server.pluginSchedulePromises[taskName][pluginConfigId] = null
             })
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,7 @@ import { Pool } from 'pg'
 import * as schedule from 'node-schedule'
 import Redis from 'ioredis'
 import { FastifyInstance } from 'fastify'
-import { PluginsServer, PluginsServerConfig } from './types'
+import { PluginConfigId, PluginsServer, PluginsServerConfig } from './types'
 import { startQueue } from './worker/queue'
 import { startFastifyInstance, stopFastifyInstance } from './web/server'
 import { Worker } from 'celery/worker'
@@ -13,6 +13,7 @@ import Piscina from 'piscina'
 import * as Sentry from '@sentry/node'
 import { delay } from './utils'
 import { StatsD } from 'hot-shots'
+import { processError } from './error'
 
 export async function createServer(
     config: Partial<PluginsServerConfig> = {},
@@ -60,7 +61,9 @@ export async function createServer(
         pluginConfigs: new Map(),
         pluginConfigsPerTeam: new Map(),
         defaultConfigs: [],
+
         pluginSchedule: { runEveryMinute: [], runEveryHour: [], runEveryDay: [] },
+        pluginSchedulePromises: { runEveryMinute: {}, runEveryHour: {}, runEveryDay: {} },
     }
 
     const closeServer = async () => {
@@ -83,6 +86,9 @@ export async function startPluginsServer(
     let fastifyInstance: FastifyInstance | undefined
     let pingJob: schedule.Job | undefined
     let statsJob: schedule.Job | undefined
+    let runEveryDayJob: schedule.Job | undefined
+    let runEveryHourJob: schedule.Job | undefined
+    let runEveryMinuteJob: schedule.Job | undefined
     let piscina: Piscina | undefined
     let queue: Worker | undefined
     let closeServer: () => Promise<void> | undefined
@@ -104,12 +110,11 @@ export async function startPluginsServer(
         }
         await queue?.stop()
         pubSub?.disconnect()
-        if (pingJob) {
-            schedule.cancelJob(pingJob)
-        }
-        if (statsJob) {
-            schedule.cancelJob(statsJob)
-        }
+        pingJob && schedule.cancelJob(pingJob)
+        statsJob && schedule.cancelJob(statsJob)
+        runEveryDayJob && schedule.cancelJob(runEveryDayJob)
+        runEveryHourJob && schedule.cancelJob(runEveryHourJob)
+        runEveryMinuteJob && schedule.cancelJob(runEveryMinuteJob)
         await stopPiscina(piscina!)
         await closeServer()
 
@@ -146,6 +151,7 @@ export async function startPluginsServer(
                 await stopPiscina(piscina!)
                 piscina = makePiscina(serverConfig!)
                 queue = startQueue(server!, processEvent)
+                server!.pluginSchedule = await piscina.runTask('getPluginSchedule')
             }
         })
 
@@ -163,6 +169,19 @@ export async function startPluginsServer(
                 server!.statsd?.gauge(`piscina.queue_size`, piscina?.queueSize)
             }
         })
+
+        server.pluginSchedule = await piscina.runTask('getPluginSchedule')
+
+        runEveryMinuteJob = schedule.scheduleJob('* * * * * *', () => {
+            runTasksDebounced(server!, piscina!, 'runEveryMinute')
+        })
+        runEveryHourJob = schedule.scheduleJob('0 * * * * *', () => {
+            runTasksDebounced(server!, piscina!, 'runEveryHour')
+        })
+        runEveryDayJob = schedule.scheduleJob('0 0 * * * *', () => {
+            runTasksDebounced(server!, piscina!, 'runEveryDay')
+        })
+
         console.info(`🚀 All systems go.`)
     } catch (error) {
         Sentry.captureException(error)
@@ -179,4 +198,28 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
     // TODO: better "wait until everything is done"
     await delay(2000)
     await piscina.destroy()
+}
+
+function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskName: string) {
+    const runTask = (pluginConfigId: PluginConfigId) =>
+        piscina!.runTask({ task: `tasks.${taskName}`, args: { pluginConfigId } })
+
+    for (const pluginConfigId of server.pluginSchedule[taskName]) {
+        // last task still running? skip rerunning!
+        if (server!.pluginSchedulePromises[pluginConfigId]) {
+            break
+        }
+
+        const promise = runTask(pluginConfigId)
+        server.pluginSchedulePromises[taskName][pluginConfigId] = promise
+
+        promise
+            .then(() => {
+                server.pluginSchedulePromises[taskName][pluginConfigId] = null
+            })
+            .catch(async (error) => {
+                await processError(server, server.pluginConfigs.get(pluginConfigId)!, error)
+                server.pluginSchedulePromises[taskName][pluginConfigId] = null
+            })
+    }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -202,12 +202,12 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
 
 export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskName: string) {
     const runTask = (pluginConfigId: PluginConfigId) =>
-        piscina!.runTask({ task: `tasks.${taskName}`, args: { pluginConfigId } })
+        piscina.runTask({ task: `tasks.${taskName}`, args: { pluginConfigId } })
 
     for (const pluginConfigId of server.pluginSchedule[taskName]) {
         // last task still running? skip rerunning!
-        if (server!.pluginSchedulePromises[pluginConfigId]) {
-            break
+        if (server.pluginSchedulePromises[taskName][pluginConfigId]) {
+            continue
         }
 
         const promise = runTask(pluginConfigId)

--- a/src/server.ts
+++ b/src/server.ts
@@ -60,6 +60,7 @@ export async function createServer(
         pluginConfigs: new Map(),
         pluginConfigsPerTeam: new Map(),
         defaultConfigs: [],
+        pluginSchedule: { runEveryMinute: [], runEveryHour: [], runEveryDay: [] },
     }
 
     const closeServer = async () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -174,13 +174,13 @@ export async function startPluginsServer(
 
         server.pluginSchedule = await piscina.runTask({ task: 'getPluginSchedule' })
 
-        runEveryMinuteJob = schedule.scheduleJob('* * * * * *', () => {
+        runEveryMinuteJob = schedule.scheduleJob('* * * * *', () => {
             runTasksDebounced(server!, piscina!, 'runEveryMinute')
         })
-        runEveryHourJob = schedule.scheduleJob('0 * * * * *', () => {
+        runEveryHourJob = schedule.scheduleJob('0 * * * *', () => {
             runTasksDebounced(server!, piscina!, 'runEveryHour')
         })
-        runEveryDayJob = schedule.scheduleJob('0 0 * * * *', () => {
+        runEveryDayJob = schedule.scheduleJob('0 0 * * *', () => {
             runTasksDebounced(server!, piscina!, 'runEveryDay')
         })
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -201,8 +201,7 @@ export async function stopPiscina(piscina: Piscina): Promise<void> {
 }
 
 export function runTasksDebounced(server: PluginsServer, piscina: Piscina, taskName: string) {
-    const runTask = (pluginConfigId: PluginConfigId) =>
-        piscina.runTask({ task: `tasks.${taskName}`, args: { pluginConfigId } })
+    const runTask = (pluginConfigId: PluginConfigId) => piscina.runTask({ task: taskName, args: { pluginConfigId } })
 
     for (const pluginConfigId of server.pluginSchedule[taskName]) {
         // last task still running? skip rerunning!

--- a/src/sql.ts
+++ b/src/sql.ts
@@ -1,4 +1,4 @@
-import { Plugin, PluginAttachmentDB, PluginConfig, PluginError, PluginsServer } from './types'
+import { Plugin, PluginAttachmentDB, PluginConfig, PluginConfigId, PluginError, PluginsServer } from './types'
 
 // This nice "mocking" system is used since we want to mock data in worker threads.
 // Jest mocks don't penetrate that far. Improvements welcome.
@@ -39,7 +39,10 @@ export async function getPluginConfigRows(server: PluginsServer): Promise<Plugin
 export async function setError(
     server: PluginsServer,
     pluginError: PluginError | null,
-    pluginConfig: PluginConfig
+    pluginConfig: PluginConfig | PluginConfigId
 ): Promise<void> {
-    await server.db.query('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [pluginError, pluginConfig.id])
+    await server.db.query('UPDATE posthog_pluginconfig SET error = $1 WHERE id = $2', [
+        pluginError,
+        typeof pluginConfig === 'object' ? pluginConfig?.id : pluginConfig,
+    ])
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,7 +116,7 @@ export interface PluginAttachmentDB {
 export interface PluginTask {
     name: string
     type: 'runEvery'
-    exec: () => Promise<void>
+    exec: () => Promise<any>
 }
 
 export interface PluginConfigVMReponse {
@@ -125,9 +125,5 @@ export interface PluginConfigVMReponse {
         processEvent: (event: PluginEvent) => Promise<PluginEvent>
         processEventBatch: (batch: PluginEvent[]) => Promise<PluginEvent[]>
     }
-    tasks: {
-        runEveryMinute?: PluginTask
-        runEveryHour?: PluginTask
-        runEveryDay?: PluginTask
-    }
+    tasks: Record<string, PluginTask>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -107,11 +107,10 @@ export interface PluginAttachmentDB {
     contents: Buffer | null
 }
 
-export interface PluginScript {
-    plugin: Plugin
-    script: VMScript
-    processEvent: boolean
-    setupTeam: boolean
+export interface PluginTask {
+    key: string
+    type: 'runEvery'
+    exec: () => Promise<void>
 }
 
 export interface PluginConfigVMReponse {
@@ -119,5 +118,10 @@ export interface PluginConfigVMReponse {
     methods: {
         processEvent: (event: PluginEvent) => Promise<PluginEvent>
         processEventBatch: (batch: PluginEvent[]) => Promise<PluginEvent[]>
+    }
+    schedule: {
+        runEveryMinute?: PluginTask
+        runEveryHour?: PluginTask
+        runEveryDay?: PluginTask
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,10 +58,10 @@ export type TeamId = number
 export interface Plugin {
     id: PluginId
     name: string
-    description: string
-    url: string
+    description?: string
+    url?: string
     config_schema: Record<string, PluginConfigSchema> | PluginConfigSchema[]
-    tag: string
+    tag?: string
     archive: Buffer | null
     error?: PluginError
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,12 +49,8 @@ export interface PluginsServer extends PluginsServerConfig {
     pluginConfigs: Map<PluginConfigId, PluginConfig>
     pluginConfigsPerTeam: Map<TeamId, PluginConfig[]>
     defaultConfigs: PluginConfig[]
-    pluginSchedule: Record<string, PluginTaskContainer[]>
-}
-
-export type PluginTaskContainer = {
-    pluginConfig: PluginConfig
-    task: PluginTask
+    pluginSchedule: Record<string, PluginConfigId[]>
+    pluginSchedulePromises: Record<string, Record<PluginConfigId, Promise<any> | null>>
 }
 
 export type PluginId = number

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,12 @@ export interface PluginsServer extends PluginsServerConfig {
     pluginConfigs: Map<PluginConfigId, PluginConfig>
     pluginConfigsPerTeam: Map<TeamId, PluginConfig[]>
     defaultConfigs: PluginConfig[]
+    pluginSchedule: Record<string, PluginTaskContainer[]>
+}
+
+export type PluginTaskContainer = {
+    pluginConfig: PluginConfig
+    task: PluginTask
 }
 
 export type PluginId = number
@@ -108,7 +114,7 @@ export interface PluginAttachmentDB {
 }
 
 export interface PluginTask {
-    key: string
+    name: string
     type: 'runEvery'
     exec: () => Promise<void>
 }
@@ -119,7 +125,7 @@ export interface PluginConfigVMReponse {
         processEvent: (event: PluginEvent) => Promise<PluginEvent>
         processEventBatch: (batch: PluginEvent[]) => Promise<PluginEvent[]>
     }
-    schedule: {
+    tasks: {
         runEveryMinute?: PluginTask
         runEveryHour?: PluginTask
         runEveryDay?: PluginTask

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -96,13 +96,13 @@ export function createPluginConfigVM(
             processEventBatch: __bindMeta('processEventBatch')
         };
         
-        // parse the runEveryX commands and export in __schedule
-        const __schedule = {};
+        // gather the runEveryX commands and export in __tasks
+        const __tasks = {};
         for (const exportDestination of __getExportDestinations().reverse()) {
-            for (const [key, value] of Object.entries(exportDestination)) {
-                if (key.startsWith("runEvery") && typeof value === 'function') {
-                    __schedule[key] = {
-                        key: key,
+            for (const [name, value] of Object.entries(exportDestination)) {
+                if (name.startsWith("runEvery") && typeof value === 'function') {
+                    __tasks[name] = {
+                        name: name,
                         type: 'runEvery',
                         exec: __bindMeta(value)
                     }
@@ -115,6 +115,6 @@ export function createPluginConfigVM(
     return {
         vm,
         methods: vm.run('__methods'),
-        schedule: vm.run('__schedule'),
+        tasks: vm.run('__tasks'),
     }
 }

--- a/src/vm.ts
+++ b/src/vm.ts
@@ -42,7 +42,10 @@ export function createPluginConfigVM(
         // two ways packages could export themselves (plus "global")
         const module = { exports: {} };
         let exports = {};
-        const __getExported = (key) => exports[key] || module.exports[key] || global[key]; 
+        
+        // helpers to get globals
+        const __getExportDestinations = () => [exports, module.exports, global]
+        const __getExported = (key) => __getExportDestinations().find(a => a[key])?.[key];
         
         // the plugin JS code        
         ${libJs};
@@ -92,11 +95,26 @@ export function createPluginConfigVM(
             processEvent: __bindMeta('processEvent'),
             processEventBatch: __bindMeta('processEventBatch')
         };
+        
+        // parse the runEveryX commands and export in __schedule
+        const __schedule = {};
+        for (const exportDestination of __getExportDestinations().reverse()) {
+            for (const [key, value] of Object.entries(exportDestination)) {
+                if (key.startsWith("runEvery") && typeof value === 'function') {
+                    __schedule[key] = {
+                        key: key,
+                        type: 'runEvery',
+                        exec: __bindMeta(value)
+                    }
+                }
+            }
+        }
         `
     )
 
     return {
         vm,
         methods: vm.run('__methods'),
+        schedule: vm.run('__schedule'),
     }
 }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -41,10 +41,9 @@ export async function createWorker(config: PluginsServerConfig, threadId: number
         if (task === 'getPluginSchedule') {
             response = cloneObject(server.pluginSchedule)
         }
-        if (task.startsWith('tasks.')) {
-            const taskName = task.substring(6)
+        if (task.startsWith('runEvery')) {
             const { pluginConfigId } = args
-            response = cloneObject(await runPluginTask(server, taskName, pluginConfigId))
+            response = cloneObject(await runPluginTask(server, task, pluginConfigId))
         }
         server.statsd?.timing(`piscina_task.${task}`, timer)
         return response

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -38,10 +38,13 @@ export async function createWorker(config: PluginsServerConfig, threadId: number
             // must clone the object, as we may get from VM2 something like { ..., properties: Proxy {} }
             response = cloneObject(processedEvents as any[])
         }
+        if (task === 'getPluginSchedule') {
+            response = cloneObject(server.pluginSchedule)
+        }
         if (task.startsWith('tasks.')) {
             const taskName = task.substring(6)
             const { pluginConfigId } = args
-            response = await runPluginTask(server, taskName, pluginConfigId)
+            response = cloneObject(await runPluginTask(server, taskName, pluginConfigId))
         }
         server.statsd?.timing(`piscina_task.${task}`, timer)
         return response

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -7,9 +7,9 @@ import { initApp } from '../init'
 type TaskWorker = ({ task, args }: { task: string; args: any }) => Promise<any>
 
 export async function createWorker(config: PluginsServerConfig, threadId: number): Promise<TaskWorker> {
-    console.info(`🧵 Starting Piscina worker thread ${threadId}…`)
-
     initApp(config)
+
+    console.info(`🧵 Starting Piscina worker thread ${threadId}…`)
 
     const [server, closeServer] = await createServer(config, threadId)
     await setupPlugins(server)

--- a/tests/helpers/worker.ts
+++ b/tests/helpers/worker.ts
@@ -1,0 +1,14 @@
+import { makePiscina } from '../../src/worker/piscina'
+import { defaultConfig } from '../../src/config'
+import { LogLevel } from '../../src/types'
+import { mockJestWithIndex } from './plugins'
+
+export function setupPiscina(workers: number, code: string, tasksPerWorker: number) {
+    return makePiscina({
+        ...defaultConfig,
+        WORKER_CONCURRENCY: workers,
+        TASKS_PER_WORKER: tasksPerWorker,
+        LOG_LEVEL: LogLevel.Log,
+        __jestMock: mockJestWithIndex(code),
+    })
+}

--- a/tests/plugins.test.ts
+++ b/tests/plugins.test.ts
@@ -231,7 +231,9 @@ test('plugin with http urls must have an archive', async () => {
     expect(pluginConfigs.get(39)!.plugin!.url).toContain('https://')
     expect(setError).toHaveBeenCalled()
     expect(setError.mock.calls[0][0]).toEqual(mockServer)
-    expect(setError.mock.calls[0][1]!.message).toEqual('Un-downloaded remote plugins not supported!')
+    expect(setError.mock.calls[0][1]!.message).toEqual(
+        'Un-downloaded remote plugins not supported! Plugin: "test-maxmind-plugin"'
+    )
     expect(setError.mock.calls[0][1]!.time).toBeDefined()
     expect(pluginConfigs.get(39)!.vm).toEqual(null)
 })

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -38,7 +38,7 @@ test('runTasksDebounced', async () => {
     const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
     const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
 
-    const [server] = await createServer({ LOG_LEVEL: LogLevel.Log })
+    const [server, closeServer] = await createServer({ LOG_LEVEL: LogLevel.Log })
     server.pluginSchedule = await getPluginSchedule()
     expect(server.pluginSchedule).toEqual({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
 
@@ -60,6 +60,7 @@ test('runTasksDebounced', async () => {
 
     await piscina.destroy()
     await waitForTasksToFinish(server)
+    await closeServer()
 })
 
 test('runTasksDebounced exception', async () => {
@@ -72,7 +73,7 @@ test('runTasksDebounced exception', async () => {
     const piscina = setupPiscina(workerThreads, testCode, 10)
 
     const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
-    const [server] = await createServer({ LOG_LEVEL: LogLevel.Log })
+    const [server, closeServer] = await createServer({ LOG_LEVEL: LogLevel.Log })
     server.pluginSchedule = await getPluginSchedule()
 
     runTasksDebounced(server, piscina, 'runEveryMinute')
@@ -83,4 +84,5 @@ test('runTasksDebounced exception', async () => {
     // and we're not testing it E2E so we can't check the DB either...
 
     await piscina.destroy()
+    await closeServer()
 })

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -2,42 +2,63 @@ import { setupPiscina } from './helpers/worker'
 import { createServer, runTasksDebounced } from '../src/server'
 import { LogLevel } from '../src/types'
 import { delay } from '../src/utils'
+import { PluginEvent } from 'posthog-plugins/src/types'
+
+function createEvent(index = 0): PluginEvent {
+    return {
+        distinct_id: 'my_id',
+        ip: '127.0.0.1',
+        site_url: 'http://localhost',
+        team_id: 2,
+        now: new Date().toISOString(),
+        event: 'default event',
+        properties: { key: 'value', index },
+    }
+}
 
 test('runTasksDebounced', async () => {
     const workerThreads = 2
     const testCode = `
+        const counterKey = 'test_counter_2'
         async function setupPlugin (meta) {
-            console.log('setting up')
-            await meta.cache.set('test_counter_2', 0)
+            await meta.cache.set(counterKey, 0)
         } 
+        async function processEvent (event, meta) {
+            event.properties['counter'] = await meta.cache.get(counterKey)
+            return event 
+        }
         async function runEveryMinute (meta) {
-            console.log('!!!')
-            console.log(meta)
-            const counter = await meta.cache.get('test_counter_2', 0)
-            console.log('!!!')
-            await new Promise(resolve => __setSetTimeout(resolve, 1000))
-            console.log('!!!')
-            await meta.cache.set('test_counter_2', counter + 1)
-            console.log('!!!')
-        } 
+            // stall for a second
+            await new Promise(resolve => __jestSetTimeout(resolve, 500))
+            await meta.cache.incr(counterKey)
+        }
     `
     const piscina = setupPiscina(workerThreads, testCode, 10)
 
     const runEveryDay = (pluginConfigId: number) =>
         piscina.runTask({ task: 'tasks.runEveryDay', args: { pluginConfigId } })
     const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
+    const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
 
     const [server] = await createServer({ LOG_LEVEL: LogLevel.Log })
     server.pluginSchedule = await getPluginSchedule()
     expect(server.pluginSchedule).toEqual({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
 
-    // await delay(100)
+    const event1 = await processEvent(createEvent())
+    expect(event1.properties['counter']).toBe(0)
 
     runTasksDebounced(server, piscina, 'runEveryMinute')
+    runTasksDebounced(server, piscina, 'runEveryMinute')
+    runTasksDebounced(server, piscina, 'runEveryMinute')
     await delay(100)
-    expect(await server.redis.get('test_counter_2')).toEqual(0)
-    await delay(1000)
-    expect(await server.redis.get('test_counter_2')).toEqual(1)
+
+    const event2 = await processEvent(createEvent())
+    expect(event2.properties['counter']).toBe(0)
+
+    await delay(500)
+
+    const event3 = await processEvent(createEvent())
+    expect(event3.properties['counter']).toBe(1)
 
     await piscina.destroy()
 })

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,5 +1,5 @@
 import { setupPiscina } from './helpers/worker'
-import { createServer, runTasksDebounced } from '../src/server'
+import { createServer, runTasksDebounced, waitForTasksToFinish } from '../src/server'
 import { LogLevel } from '../src/types'
 import { delay } from '../src/utils'
 import { PluginEvent } from 'posthog-plugins/src/types'
@@ -35,8 +35,6 @@ test('runTasksDebounced', async () => {
     `
     const piscina = setupPiscina(workerThreads, testCode, 10)
 
-    const runEveryDay = (pluginConfigId: number) =>
-        piscina.runTask({ task: 'tasks.runEveryDay', args: { pluginConfigId } })
     const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
     const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
 
@@ -61,4 +59,5 @@ test('runTasksDebounced', async () => {
     expect(event3.properties['counter']).toBe(1)
 
     await piscina.destroy()
+    await waitForTasksToFinish(server)
 })

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,0 +1,43 @@
+import { setupPiscina } from './helpers/worker'
+import { createServer, runTasksDebounced } from '../src/server'
+import { LogLevel } from '../src/types'
+import { delay } from '../src/utils'
+
+test('runTasksDebounced', async () => {
+    const workerThreads = 2
+    const testCode = `
+        async function setupPlugin (meta) {
+            console.log('setting up')
+            await meta.cache.set('test_counter_2', 0)
+        } 
+        async function runEveryMinute (meta) {
+            console.log('!!!')
+            console.log(meta)
+            const counter = await meta.cache.get('test_counter_2', 0)
+            console.log('!!!')
+            await new Promise(resolve => __setSetTimeout(resolve, 1000))
+            console.log('!!!')
+            await meta.cache.set('test_counter_2', counter + 1)
+            console.log('!!!')
+        } 
+    `
+    const piscina = setupPiscina(workerThreads, testCode, 10)
+
+    const runEveryDay = (pluginConfigId: number) =>
+        piscina.runTask({ task: 'tasks.runEveryDay', args: { pluginConfigId } })
+    const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
+
+    const [server] = await createServer({ LOG_LEVEL: LogLevel.Log })
+    server.pluginSchedule = await getPluginSchedule()
+    expect(server.pluginSchedule).toEqual({ runEveryDay: [], runEveryHour: [], runEveryMinute: [39] })
+
+    // await delay(100)
+
+    runTasksDebounced(server, piscina, 'runEveryMinute')
+    await delay(100)
+    expect(await server.redis.get('test_counter_2')).toEqual(0)
+    await delay(1000)
+    expect(await server.redis.get('test_counter_2')).toEqual(1)
+
+    await piscina.destroy()
+})

--- a/tests/vm.test.ts
+++ b/tests/vm.test.ts
@@ -55,7 +55,7 @@ test('empty plugins', async () => {
     const libJs = ''
     const vm = createPluginConfigVM(mockServer, mockConfig, indexJs, libJs)
 
-    expect(Object.keys(vm).sort()).toEqual(['methods', 'schedule', 'vm'])
+    expect(Object.keys(vm).sort()).toEqual(['methods', 'tasks', 'vm'])
     expect(Object.keys(vm.methods).sort()).toEqual(['processEvent', 'processEventBatch'])
     expect(vm.methods.processEvent).toEqual(undefined)
     expect(vm.methods.processEventBatch).toEqual(undefined)

--- a/tests/vm.test.ts
+++ b/tests/vm.test.ts
@@ -575,3 +575,23 @@ test('attachments', async () => {
 
     expect(event.properties).toEqual(attachments)
 })
+
+test('schedule', async () => {
+    const indexJs = `
+        function runEveryMinute(meta) {
+            
+        }
+        function runEveryHour(meta) {
+            
+        }
+        function runEveryDay(meta) {
+            
+        }
+    `
+    const vm = createPluginConfigVM(mockServer, mockConfig, indexJs)
+
+    expect(Object.keys(vm.schedule)).toEqual(['runEveryMinute', 'runEveryHour', 'runEveryDay'])
+    expect(Object.values(vm.schedule).map((v) => v?.key)).toEqual(['runEveryMinute', 'runEveryHour', 'runEveryDay'])
+    expect(Object.values(vm.schedule).map((v) => v?.type)).toEqual(['runEvery', 'runEvery', 'runEvery'])
+    expect(Object.values(vm.schedule).map((v) => typeof v?.exec)).toEqual(['function', 'function', 'function'])
+})

--- a/tests/vm.test.ts
+++ b/tests/vm.test.ts
@@ -366,8 +366,11 @@ test('meta.config', async () => {
 
 test('meta.cache set/get', async () => {
     const indexJs = `
+        async function setupPlugin (meta) {
+            await meta.cache.set('counter', 0)
+        }
         async function processEvent (event, meta) {
-            const counter = await meta.cache.get('counter', 0)
+            const counter = await meta.cache.get('counter', 999)
             meta.cache.set('counter', counter + 1)
             event.properties['counter'] = counter + 1
             return event

--- a/tests/vm.test.ts
+++ b/tests/vm.test.ts
@@ -55,7 +55,7 @@ test('empty plugins', async () => {
     const libJs = ''
     const vm = createPluginConfigVM(mockServer, mockConfig, indexJs, libJs)
 
-    expect(Object.keys(vm).sort()).toEqual(['methods', 'vm'])
+    expect(Object.keys(vm).sort()).toEqual(['methods', 'schedule', 'vm'])
     expect(Object.keys(vm.methods).sort()).toEqual(['processEvent', 'processEventBatch'])
     expect(vm.methods.processEvent).toEqual(undefined)
     expect(vm.methods.processEventBatch).toEqual(undefined)
@@ -576,7 +576,7 @@ test('attachments', async () => {
     expect(event.properties).toEqual(attachments)
 })
 
-test('schedule', async () => {
+test('runEvery', async () => {
     const indexJs = `
         function runEveryMinute(meta) {
             
@@ -590,8 +590,24 @@ test('schedule', async () => {
     `
     const vm = createPluginConfigVM(mockServer, mockConfig, indexJs)
 
-    expect(Object.keys(vm.schedule)).toEqual(['runEveryMinute', 'runEveryHour', 'runEveryDay'])
-    expect(Object.values(vm.schedule).map((v) => v?.key)).toEqual(['runEveryMinute', 'runEveryHour', 'runEveryDay'])
-    expect(Object.values(vm.schedule).map((v) => v?.type)).toEqual(['runEvery', 'runEvery', 'runEvery'])
-    expect(Object.values(vm.schedule).map((v) => typeof v?.exec)).toEqual(['function', 'function', 'function'])
+    expect(Object.keys(vm.tasks)).toEqual(['runEveryMinute', 'runEveryHour', 'runEveryDay'])
+    expect(Object.values(vm.tasks).map((v) => v?.name)).toEqual(['runEveryMinute', 'runEveryHour', 'runEveryDay'])
+    expect(Object.values(vm.tasks).map((v) => v?.type)).toEqual(['runEvery', 'runEvery', 'runEvery'])
+    expect(Object.values(vm.tasks).map((v) => typeof v?.exec)).toEqual(['function', 'function', 'function'])
+})
+
+test('runEvery must be a function', async () => {
+    const indexJs = `
+        function runEveryMinute(meta) {
+            
+        }
+        const runEveryHour = false
+        const runEveryDay = { some: 'object' }
+    `
+    const vm = createPluginConfigVM(mockServer, mockConfig, indexJs)
+
+    expect(Object.keys(vm.tasks)).toEqual(['runEveryMinute'])
+    expect(Object.values(vm.tasks).map((v) => v?.name)).toEqual(['runEveryMinute'])
+    expect(Object.values(vm.tasks).map((v) => v?.type)).toEqual(['runEvery'])
+    expect(Object.values(vm.tasks).map((v) => typeof v?.exec)).toEqual(['function'])
 })

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,8 +1,5 @@
-import { makePiscina } from '../src/worker/piscina'
-import { defaultConfig } from '../src/config'
 import { PluginEvent } from 'posthog-plugins/src/types'
-import { mockJestWithIndex } from './helpers/plugins'
-import { LogLevel } from '../src/types'
+import { setupPiscina } from './helpers/worker'
 
 jest.mock('../src/sql')
 jest.setTimeout(600000) // 600 sec timeout
@@ -17,16 +14,6 @@ function createEvent(index = 0): PluginEvent {
         event: 'default event',
         properties: { key: 'value', index },
     }
-}
-
-function setupPiscina(workers: number, code: string, tasksPerWorker: number) {
-    return makePiscina({
-        ...defaultConfig,
-        WORKER_CONCURRENCY: workers,
-        TASKS_PER_WORKER: tasksPerWorker,
-        LOG_LEVEL: LogLevel.Log,
-        __jestMock: mockJestWithIndex(code),
-    })
 }
 
 test('piscina worker test', async () => {

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -24,7 +24,6 @@ test('piscina worker test', async () => {
             return event
         }
         async function runEveryDay (meta) {
-            console.log('ran daily!')
             return 4
         } 
     `
@@ -32,8 +31,7 @@ test('piscina worker test', async () => {
 
     const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
     const processEventBatch = (batch: PluginEvent[]) => piscina.runTask({ task: 'processEventBatch', args: { batch } })
-    const runEveryDay = (pluginConfigId: number) =>
-        piscina.runTask({ task: 'tasks.runEveryDay', args: { pluginConfigId } })
+    const runEveryDay = (pluginConfigId: number) => piscina.runTask({ task: 'runEveryDay', args: { pluginConfigId } })
     const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
 
     const pluginSchedule = await getPluginSchedule()
@@ -59,7 +57,6 @@ test('scheduled task test', async () => {
             return event
         }
         async function runEveryDay (meta) {
-            console.log('ran daily!')
             return 4
         } 
     `
@@ -67,8 +64,7 @@ test('scheduled task test', async () => {
 
     const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
     const processEventBatch = (batch: PluginEvent[]) => piscina.runTask({ task: 'processEventBatch', args: { batch } })
-    const runEveryDay = (pluginConfigId: number) =>
-        piscina.runTask({ task: 'tasks.runEveryDay', args: { pluginConfigId } })
+    const runEveryDay = (pluginConfigId: number) => piscina.runTask({ task: 'runEveryDay', args: { pluginConfigId } })
     const getPluginSchedule = () => piscina.runTask({ task: 'getPluginSchedule' })
 
     const pluginSchedule = await getPluginSchedule()

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,0 +1,60 @@
+import { makePiscina } from '../src/worker/piscina'
+import { defaultConfig } from '../src/config'
+import { PluginEvent } from 'posthog-plugins/src/types'
+import { mockJestWithIndex } from './helpers/plugins'
+import { LogLevel } from '../src/types'
+
+jest.mock('../src/sql')
+jest.setTimeout(600000) // 600 sec timeout
+
+function createEvent(index = 0): PluginEvent {
+    return {
+        distinct_id: 'my_id',
+        ip: '127.0.0.1',
+        site_url: 'http://localhost',
+        team_id: 2,
+        now: new Date().toISOString(),
+        event: 'default event',
+        properties: { key: 'value', index },
+    }
+}
+
+function setupPiscina(workers: number, code: string, tasksPerWorker: number) {
+    return makePiscina({
+        ...defaultConfig,
+        WORKER_CONCURRENCY: workers,
+        TASKS_PER_WORKER: tasksPerWorker,
+        LOG_LEVEL: LogLevel.Log,
+        __jestMock: mockJestWithIndex(code),
+    })
+}
+
+test('piscina worker test', async () => {
+    const workerThreads = 2
+    const testCode = `
+        function processEvent (event, meta) {
+            event.properties["somewhere"] = "over the rainbow";
+            return event
+        }
+        async function runEveryDay (meta) {
+            console.log('ran daily!')
+            return 4
+        } 
+    `
+    const piscina = setupPiscina(workerThreads, testCode, 10)
+
+    const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
+    const processEventBatch = (batch: PluginEvent[]) => piscina.runTask({ task: 'processEventBatch', args: { batch } })
+    const runEveryDay = () => piscina.runTask({ task: 'tasks.runEveryDay', args: { pluginConfigId: 39 } })
+
+    const event = await processEvent(createEvent())
+    expect(event.properties['somewhere']).toBe('over the rainbow')
+
+    const eventBatch = await processEventBatch([createEvent()])
+    expect(eventBatch[0]!.properties['somewhere']).toBe('over the rainbow')
+
+    const everyDayReturn = await runEveryDay()
+    expect(everyDayReturn).toBe(4)
+
+    await piscina.destroy()
+})


### PR DESCRIPTION
This implements scheduled tasks inside plugins!

Inside plugins you can now use three extra functions: `runEveryMinute(meta)`, `runEveryHour(meta)`, `runEveryDay(meta)`

```js
async function runEveryMinute (meta) {
    const cursor = await meta.cache.get('last_fetched_cursor')
    const response = await fetch(`http://my.api.com/get_stargazers?since=${cursor}`)
    for (const { username } of response.stargazers) {
        posthog.capture('someone starred you!', { username })
    }
    const last_cursor = response.stargazers.map(s => s.created_at).sort().reverse()[0] || cursor
    await meta.cache.set('last_fetched_cursor', last_cursor)
}
```

The above is still pseudocode (need to re-enable the `posthog` var), but this should basically work.

The functions are currently run per worker, but not per thread (so one time per worker instance per minute/hour/day). There's no locking system to prevent code from running e.g. 2 times if you have 2 plugin servers running. I think this is fine for a lot of cases though and definitely OK for a beta!