### PR TITLE
Celery queue backpressure

### DIFF
--- a/benchmarks/memory.benchmark.ts
+++ b/benchmarks/memory.benchmark.ts
@@ -1,0 +1,99 @@
+import { createPluginConfigVM } from '../src/vm'
+import { Plugin, PluginConfig, PluginConfigVMReponse } from '../src/types'
+import { createServer } from '../src/server'
+import { PluginEvent } from 'posthog-plugins/src/types'
+
+jest.mock('../src/sql')
+
+function createEvent(index: number): PluginEvent {
+    return {
+        distinct_id: 'my_id',
+        ip: '127.0.0.1',
+        site_url: 'http://localhost',
+        team_id: 2,
+        now: new Date().toISOString(),
+        event: 'default event',
+        properties: { key: 'value', index },
+    }
+}
+
+const mockPlugin: Plugin = {
+    id: 4,
+    plugin_type: 'custom',
+    name: 'mock-plugin',
+    description: 'Mock Plugin in Tests',
+    url: 'http://plugins.posthog.com/mock-plugin',
+    config_schema: {},
+    tag: 'v1.0.0',
+    archive: null,
+    error: undefined,
+}
+
+const mockConfig: PluginConfig = {
+    id: 4,
+    team_id: 2,
+    plugin: mockPlugin,
+    plugin_id: mockPlugin.id,
+    enabled: true,
+    order: 0,
+    config: { configKey: 'configValue' },
+    error: undefined,
+    attachments: {},
+    vm: null,
+}
+
+test('test vm memory usage', async () => {
+    const numVMs = 1000
+    const numEventsPerVM = 100
+
+    const [server, closeServer] = await createServer()
+    const indexJs = `
+        async function processEvent (event, meta) {
+            event.event = 'changed event'
+            return event
+        }
+        
+        async function runEveryMinute (meta) {
+            console.log('I take up space')
+        }
+    `
+
+    // 10kb of maxmind plugin, uncomment if testing locally
+    // const indexJs = fs.readFileSync(path.resolve(__dirname, '../../posthog-maxmind-plugin/dist/index.js')).toString()
+
+    const getUsed = () => process.memoryUsage().heapUsed / (1024 * 1024)
+
+    const usedAtStart = getUsed()
+
+    let used = usedAtStart
+    const vms: PluginConfigVMReponse[] = []
+
+    for (let i = 0; i < numVMs; i++) {
+        const vm = createPluginConfigVM(server, mockConfig, indexJs)
+        vms.push(vm)
+
+        const nowUsed = getUsed()
+        console.log(
+            `Used: ${nowUsed} MB, diff ${nowUsed - used} (${(nowUsed - usedAtStart) / (i + 1)} * ${
+                i + 1
+            } used since the start)`
+        )
+        used = nowUsed
+    }
+
+    for (let i = 0; i < numEventsPerVM; i++) {
+        for (let j = 0; j < numVMs; j++) {
+            await vms[j].methods.processEvent(createEvent(i + j))
+        }
+        global.gc()
+        const nowUsed = getUsed()
+        console.log(
+            `Run ${i}. Used: ${nowUsed} MB, diff ${nowUsed - used} (${nowUsed - usedAtStart} used since the start, ${
+                (nowUsed - usedAtStart) / numVMs
+            } per vm)`
+        )
+        used = nowUsed
+    }
+
+    await closeServer()
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "main": "dist/src/index.js",
     "scripts": {
         "test": "jest --testPathIgnorePatterns='benchmarks/'",
-        "benchmark": "jest --runInBand benchmarks/",
+        "benchmark": "node --expose-gc node_modules/.bin/jest --runInBand benchmarks/",
         "start": "yarn start:dev",
         "start:dist": "node dist/src/index.js --base-dir ../posthog",
         "start:dev": "ts-node-dev --exit-child src/index.ts --base-dir ../posthog",

--- a/src/celery/broker.ts
+++ b/src/celery/broker.ts
@@ -23,7 +23,7 @@ class RedisMessage extends Message {
 
 export default class RedisBroker implements Pausable {
     redis: Redis.Redis
-    subsciptions: BrokerSubscription[] = []
+    subscriptions: BrokerSubscription[] = []
     channels: Promise<void>[] = []
     closing = false
     paused = false
@@ -103,7 +103,7 @@ export default class RedisBroker implements Pausable {
             return
         }
         this.paused = false
-        for (const { queue, callback } of this.subsciptions) {
+        for (const { queue, callback } of this.subscriptions) {
             this.channels.push(new Promise((resolve) => this.receiveFast(resolve, queue, callback)))
         }
     }
@@ -115,7 +115,7 @@ export default class RedisBroker implements Pausable {
      * @returns {Promise}
      */
     public subscribe(queue: string, callback: (message: Message) => any): Promise<any[]> {
-        this.subsciptions.push({ queue, callback })
+        this.subscriptions.push({ queue, callback })
         this.channels.push(new Promise((resolve) => this.receiveFast(resolve, queue, callback)))
         return Promise.all(this.channels)
     }

--- a/src/celery/broker.ts
+++ b/src/celery/broker.ts
@@ -89,6 +89,9 @@ export default class RedisBroker implements Pausable {
      * @returns {Promise}
      */
     public async pause(): Promise<void> {
+        if (this.paused) {
+            return
+        }
         const oldChannels = this.channels
         this.paused = true
         this.channels = []

--- a/src/celery/pausable.ts
+++ b/src/celery/pausable.ts
@@ -1,0 +1,4 @@
+export interface Pausable {
+    pause: () => Promise<void>
+    resume: () => void
+}

--- a/src/celery/worker.ts
+++ b/src/celery/worker.ts
@@ -64,6 +64,16 @@ export class Worker extends Base implements Pausable {
     }
 
     /**
+     * Is the worker paused
+     * @method Worker#isPaused
+     *
+     * @returns {boolean}
+     */
+    public isPaused(): boolean {
+        return this.broker.paused
+    }
+
+    /**
      * @method Worker#run
      * @private
      *

--- a/src/celery/worker.ts
+++ b/src/celery/worker.ts
@@ -1,9 +1,10 @@
 import Base from './base'
 import { Message } from './message'
+import { Pausable } from './pausable'
 
 type Handler = (...args: any[]) => Promise<void>
 
-export class Worker extends Base {
+export class Worker extends Base implements Pausable {
     handlers: Record<string, Handler> = {}
     activeTasks: Set<Promise<any>> = new Set()
 
@@ -44,6 +45,22 @@ export class Worker extends Base {
     public start(): Promise<any> {
         console.info('🍆 Starting Celery worker...')
         return this.run().catch((err) => console.error(err))
+    }
+
+    /**
+     * Pause the worker. await the response to be sure all pending `processNextTick` events have finished.
+     * @method Worker#pause
+     */
+    public pause(): Promise<void> {
+        return this.broker.pause()
+    }
+
+    /**
+     * Resume the worker
+     * @method Worker#pause
+     */
+    public resume(): void {
+        this.broker.resume()
     }
 
     /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -74,10 +74,15 @@ export async function createServer(
     return [server, closeServer]
 }
 
+// TODO: refactor this into a class, removing the need for many different Servers
+type ServerInstance = {
+    stop: () => Promise<void>
+}
+
 export async function startPluginsServer(
-    config: PluginsServerConfig,
+    config: Partial<PluginsServerConfig>,
     makePiscina: (config: PluginsServerConfig) => Piscina
-): Promise<void> {
+): Promise<ServerInstance> {
     console.info(`⚡ posthog-plugin-server v${version}`)
 
     let serverConfig: PluginsServerConfig | undefined
@@ -200,6 +205,10 @@ export async function startPluginsServer(
         await closeJobs()
 
         process.exit(1)
+    }
+
+    return {
+        stop: closeJobs,
     }
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -76,6 +76,9 @@ export async function createServer(
 
 // TODO: refactor this into a class, removing the need for many different Servers
 type ServerInstance = {
+    server: PluginsServer
+    piscina: Piscina
+    queue: Worker
     stop: () => Promise<void>
 }
 
@@ -208,6 +211,9 @@ export async function startPluginsServer(
     }
 
     return {
+        server,
+        piscina,
+        queue,
         stop: closeJobs,
     }
 }

--- a/src/worker/config.ts
+++ b/src/worker/config.ts
@@ -2,7 +2,7 @@ import { PluginsServerConfig } from '../types'
 import { TaskQueue } from 'piscina/src/common'
 
 // Copy From: node_modules/piscina/src/index.ts -- copied because it's not exported
-interface Options {
+export interface PiscinaOptions {
     filename?: string | null
     minThreads?: number
     maxThreads?: number
@@ -20,8 +20,8 @@ interface Options {
     trackUnmanagedFds?: boolean
 }
 
-export function createConfig(serverConfig: PluginsServerConfig, filename: string): Options {
-    const config: Options = {
+export function createConfig(serverConfig: PluginsServerConfig, filename: string): PiscinaOptions {
+    const config: PiscinaOptions = {
         filename,
         workerData: { serverConfig },
     }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,5 +1,6 @@
 import { PluginEvent } from 'posthog-plugins/src/types'
 import { setupPiscina } from './helpers/worker'
+import { delay } from '../src/utils'
 
 jest.mock('../src/sql')
 jest.setTimeout(600000) // 600 sec timeout
@@ -78,6 +79,39 @@ test('scheduled task test', async () => {
 
     const everyDayReturn = await runEveryDay(39)
     expect(everyDayReturn).toBe(4)
+
+    await piscina.destroy()
+})
+
+test('assume that the workerThreads and tasksPerWorker values behave as expected', async () => {
+    const workerThreads = 2
+    const tasksPerWorker = 3
+    const testCode = `
+        async function processEvent (event, meta) {
+            await new Promise(resolve => __jestSetTimeout(resolve, 300))
+            return event
+        }
+    `
+    const piscina = setupPiscina(workerThreads, testCode, tasksPerWorker)
+    const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
+    const promises = []
+
+    // warmup 2x
+    await Promise.all([processEvent(createEvent()), processEvent(createEvent())])
+
+    // process 10 events in parallel and ignore the result
+    for (let i = 0; i < 10; i++) {
+        promises.push(processEvent(createEvent()))
+    }
+    await delay(100)
+    expect(piscina.queueSize).toBe(10 - workerThreads * tasksPerWorker)
+    expect(piscina.completed).toBe(0 + 2)
+    await delay(300)
+    expect(piscina.queueSize).toBe(0)
+    expect(piscina.completed).toBe(workerThreads * tasksPerWorker + 2)
+    await delay(300)
+    expect(piscina.queueSize).toBe(0)
+    expect(piscina.completed).toBe(10 + 2)
 
     await piscina.destroy()
 })

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -101,40 +101,7 @@ test('assume that the workerThreads and tasksPerWorker values behave as expected
 
     // process 10 events in parallel and ignore the result
     for (let i = 0; i < 10; i++) {
-        promises.push(processEvent(createEvent()))
-    }
-    await delay(100)
-    expect(piscina.queueSize).toBe(10 - workerThreads * tasksPerWorker)
-    expect(piscina.completed).toBe(0 + 2)
-    await delay(300)
-    expect(piscina.queueSize).toBe(0)
-    expect(piscina.completed).toBe(workerThreads * tasksPerWorker + 2)
-    await delay(300)
-    expect(piscina.queueSize).toBe(0)
-    expect(piscina.completed).toBe(10 + 2)
-
-    await piscina.destroy()
-})
-
-test('assume that the workerThreads and tasksPerWorker values behave as expected', async () => {
-    const workerThreads = 2
-    const tasksPerWorker = 3
-    const testCode = `
-        async function processEvent (event, meta) {
-            await new Promise(resolve => __jestSetTimeout(resolve, 300))
-            return event
-        }
-    `
-    const piscina = setupPiscina(workerThreads, testCode, tasksPerWorker)
-    const processEvent = (event: PluginEvent) => piscina.runTask({ task: 'processEvent', args: { event } })
-    const promises = []
-
-    // warmup 2x
-    await Promise.all([processEvent(createEvent()), processEvent(createEvent())])
-
-    // process 10 events in parallel and ignore the result
-    for (let i = 0; i < 10; i++) {
-        promises.push(processEvent(createEvent()))
+        promises.push(processEvent(createEvent(i)))
     }
     await delay(100)
     expect(piscina.queueSize).toBe(10 - workerThreads * tasksPerWorker)


### PR DESCRIPTION
- Pauses celery if we are busy processing all the tasks we got so far
- Resumes when the workers are free again.
- Also implements a 50ms wait time for celery to receive the next event if none were received in the last round

I added a `Pausable` interface and wrote some more ugly code in `server.ts` that I'm not immensely proud of. I think the entire `server.ts` file needs to be refactored (into a class perhaps?) and I'd fix all this then.

I see that your kafka PR had a generic `Queue` interface, which I think is even better. Feel free to adjust as needed if/when you merge these things.