### PR TITLE
Simple memory benchmark

### DIFF
--- a/benchmarks/memory.benchmark.ts
+++ b/benchmarks/memory.benchmark.ts
@@ -1,0 +1,99 @@
+import { createPluginConfigVM } from '../src/vm'
+import { Plugin, PluginConfig, PluginConfigVMReponse } from '../src/types'
+import { createServer } from '../src/server'
+import { PluginEvent } from 'posthog-plugins/src/types'
+
+jest.mock('../src/sql')
+
+function createEvent(index: number): PluginEvent {
+    return {
+        distinct_id: 'my_id',
+        ip: '127.0.0.1',
+        site_url: 'http://localhost',
+        team_id: 2,
+        now: new Date().toISOString(),
+        event: 'default event',
+        properties: { key: 'value', index },
+    }
+}
+
+const mockPlugin: Plugin = {
+    id: 4,
+    plugin_type: 'custom',
+    name: 'mock-plugin',
+    description: 'Mock Plugin in Tests',
+    url: 'http://plugins.posthog.com/mock-plugin',
+    config_schema: {},
+    tag: 'v1.0.0',
+    archive: null,
+    error: undefined,
+}
+
+const mockConfig: PluginConfig = {
+    id: 4,
+    team_id: 2,
+    plugin: mockPlugin,
+    plugin_id: mockPlugin.id,
+    enabled: true,
+    order: 0,
+    config: { configKey: 'configValue' },
+    error: undefined,
+    attachments: {},
+    vm: null,
+}
+
+test('test vm memory usage', async () => {
+    const numVMs = 1000
+    const numEventsPerVM = 100
+
+    const [server, closeServer] = await createServer()
+    const indexJs = `
+        async function processEvent (event, meta) {
+            event.event = 'changed event'
+            return event
+        }
+        
+        async function runEveryMinute (meta) {
+            console.log('I take up space')
+        }
+    `
+
+    // 10kb of maxmind plugin, uncomment if testing locally
+    // const indexJs = fs.readFileSync(path.resolve(__dirname, '../../posthog-maxmind-plugin/dist/index.js')).toString()
+
+    const getUsed = () => process.memoryUsage().heapUsed / (1024 * 1024)
+
+    const usedAtStart = getUsed()
+
+    let used = usedAtStart
+    const vms: PluginConfigVMReponse[] = []
+
+    for (let i = 0; i < numVMs; i++) {
+        const vm = createPluginConfigVM(server, mockConfig, indexJs)
+        vms.push(vm)
+
+        const nowUsed = getUsed()
+        console.log(
+            `Used: ${nowUsed} MB, diff ${nowUsed - used} (${(nowUsed - usedAtStart) / (i + 1)} * ${
+                i + 1
+            } used since the start)`
+        )
+        used = nowUsed
+    }
+
+    for (let i = 0; i < numEventsPerVM; i++) {
+        for (let j = 0; j < numVMs; j++) {
+            await vms[j].methods.processEvent(createEvent(i + j))
+        }
+        global.gc()
+        const nowUsed = getUsed()
+        console.log(
+            `Run ${i}. Used: ${nowUsed} MB, diff ${nowUsed - used} (${nowUsed - usedAtStart} used since the start, ${
+                (nowUsed - usedAtStart) / numVMs
+            } per vm)`
+        )
+        used = nowUsed
+    }
+
+    await closeServer()
+})

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "main": "dist/src/index.js",
     "scripts": {
         "test": "jest --testPathIgnorePatterns='benchmarks/'",
-        "benchmark": "jest --runInBand benchmarks/",
+        "benchmark": "node --expose-gc node_modules/.bin/jest --runInBand benchmarks/",
         "start": "yarn start:dev",
         "start:dist": "node dist/src/index.js --base-dir ../posthog",
         "start:dev": "ts-node-dev --exit-child src/index.ts --base-dir ../posthog",


### PR DESCRIPTION
**Note:** Depends on PR #75

This adds another benchmark, which I used to see how much memory each VM takes for back of the envelope calculations.

Running it myself with a simple plugin that returns directly and with the maxmind plugin, although the latter uninitialized, so it returns the event directly again and does not use the 70MB database:

1. 10000 VMs, 100 events per VM, simple plugin
   - Used: 2068.36 MB, (1893.75 MB used since the start, 0.189 MB per vm)

2. 100 VMs, 10000 events per VM, simple plugin: 
      Used: 195.12 MB, (19.94 MB used since the start, 0.199 MB per vm)

3. 1000 VMs, 1000 events per VM, simple plugin
   - Used: 426.49 MB, (251.84 MB used since the start, 0.251 MB per vm)

4. 1000 VMs, 1000 events per VM, posthog-maxmind-plugin/dist/index.js (100kb of JS)
   - Used: 436.47 MB, (261.09 MB used since the start, 0.261 MB per vm)

Memory usage remains relatively steady the more events a VM processes. I don't think there's any memory leak, but only running this on the cloud for a while will confirm that.

**The conclusion**: a VM of a plugin takes about 250KB of memory on its own. Therefor we can easily start thousands of VMs per worker, provided it's a strong enough machine.