### PR TITLE
Improve repo experience

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 120
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
             - name: Checkout the repository
               uses: actions/checkout@v2
               with:
-                fetch-depth: 0
+                  fetch-depth: 0
 
             - name: Get package version
               id: version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,59 @@
+name: 'Release'
+
+on:
+    push:
+        branches:
+            - main
+            - master
+
+jobs:
+    release:
+        name: Bake a Release
+        runs-on: ubuntu-20.04
+
+        steps:
+            - name: Checkout the repository
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+
+            - name: Get package version
+              id: version
+              run: |
+                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
+                  PACKAGE_VERSION_TAG="v$PACKAGE_VERSION"
+                  if git rev-parse "$PACKAGE_VERSION_TAG"; then
+                    IS_NEW_VERSION=false
+                  else
+                    IS_NEW_VERSION=true
+                  fi
+                  echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+                  echo "PACKAGE_VERSION_TAG=$PACKAGE_VERSION_TAG" >> $GITHUB_ENV
+                  echo "IS_NEW_VERSION=$IS_NEW_VERSION" >> $GITHUB_ENV
+                  echo "::set-output name=IS_NEW_VERSION::$IS_NEW_VERSION"
+
+            - name: Set up Node 14
+              if: steps.version.outputs.IS_NEW_VERSION == 'true'
+              uses: actions/setup-node@v2
+              with:
+                  node-version: 14
+                  registry-url: https://registry.npmjs.org
+
+            - name: Install dependencies
+              if: steps.version.outputs.IS_NEW_VERSION == 'true'
+              run: yarn --frozen-lockfile
+
+            - name: Publish the package in the npm registry
+              if: steps.version.outputs.IS_NEW_VERSION == 'true'
+              run: yarn publish --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+            - name: Create GitHub release
+              if: steps.version.outputs.IS_NEW_VERSION == 'true'
+              uses: actions/create-release@v1
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  tag_name: ${{ env.PACKAGE_VERSION_TAG }}
+                  release_name: ${{ env.PACKAGE_VERSION }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# PostHog Plugin Server
+
+[![npm package](https://img.shields.io/npm/v/posthog-plugin-server?style=flat-square)](https://www.npmjs.com/package/posthog-plugin-server)
+[![License: MIT](https://img.shields.io/badge/License-MIT-red.svg?style=flat-square)](https://opensource.org/licenses/MIT)
+
+This service takes care of processing events with plugins and more.


### PR DESCRIPTION
This adds a simple README and a couple of dotfiles. Also, a pretty smart GitHub workflow that automatically publishes an npm + GitHub release whenever the version number is incremented on `master` (otherwise it's silent, ran a lot of tests to improve it, works pretty great now). The workflow needs the repo to have an `NPM_TOKEN` secret – this needs to be an automation type npm access token. I just don't have access to repo settings here.